### PR TITLE
MkDocs site + Stoplight Elements

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'openapi/**'
+      - '.github/workflows/docs-deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: "docs-deploy"
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r docs/requirements.txt
+
+      - name: Build docs (strict)
+        run: |
+          cd docs
+          mkdocs build --strict
+
+      - name: Stage OpenAPI descriptor
+        # Stoplight Elements loads the descriptor from /payments-core/openapi/...
+        # so ship openapi/ alongside the built site.
+        run: |
+          mkdir -p docs/site/openapi
+          cp openapi/payments_core.yaml docs/site/openapi/payments_core.yaml
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/site
+          publish_branch: gh-pages
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/docs/content/assets/javascripts/stoplight-elements.mjs
+++ b/docs/content/assets/javascripts/stoplight-elements.mjs
@@ -1,0 +1,6 @@
+// Stoplight Elements loader.
+// Registers the `<elements-api>` Web Component and injects its stylesheet.
+// Embedded by `extra_javascript` in `mkdocs.yml` so every page that uses
+// `<elements-api>` gets the component without per-page imports.
+import 'https://unpkg.com/@stoplight/elements/web-components.min.js';
+import 'https://unpkg.com/@stoplight/elements/styles.min.css';

--- a/docs/content/assets/stylesheets/payments-core.css
+++ b/docs/content/assets/stylesheets/payments-core.css
@@ -1,0 +1,22 @@
+/* =============================================================================
+ * payments-core — brand overrides for Material for MkDocs
+ * Minimal palette: primary/accent + a light surface tweak for landing cards.
+ * ============================================================================= */
+
+:root {
+  --md-primary-fg-color: #1f6feb;
+  --md-primary-fg-color--light: #388bfd;
+  --md-primary-fg-color--dark: #0a3d91;
+  --md-accent-fg-color: #f78166;
+}
+
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #388bfd;
+  --md-accent-fg-color: #f78166;
+}
+
+/* Stoplight Elements host container fills the content width. */
+.md-content elements-api {
+  display: block;
+  min-height: 70vh;
+}

--- a/docs/content/docs/adapters/index.md
+++ b/docs/content/docs/adapters/index.md
@@ -1,0 +1,26 @@
+# Adapters
+
+Concrete integrations that implement one or more ports. Adapters are the only
+code that talks to a real provider SDK, a real HTTP endpoint, or a real
+blockchain. Swapping one adapter for another must never require touching the
+domain or application layers.
+
+## Planned adapters
+
+- **Stripe** — cards + wallets, payments + donations. (landing with
+  `stripe-adapter-p0`)
+- **OnvoPay** — Costa Rica card acquirer. (landing with `onvopay-adapter-p0`)
+- **TiloPay** — LATAM card + SINPE Móvil. (landing with `tilopay-adapter-p1`)
+- **dLocal** — LATAM cross-border. (landing with `dlocal-adapter-p2`)
+- **Revolut Business** — multi-currency payouts + FX. (landing with
+  `revolut-adapter`)
+- **Convera** — global corporate FX & payments. (landing with
+  `convera-adapter`)
+- **Ripple / XRPL** — on-ledger settlement. (landing with
+  `ripple-xrpl-adapter`)
+- **Apple Pay / Google Pay verification** — token validation before charge.
+  (landing with `apple-google-verify-p2`)
+
+Each adapter page will document: supported operations, credentials required,
+sandbox/production flags, error-to-domain mapping, and the idempotency
+strategy.

--- a/docs/content/docs/api/index.md
+++ b/docs/content/docs/api/index.md
@@ -1,0 +1,19 @@
+# API
+
+`payments-core` publishes a gRPC service as its canonical contract. For human
+readability and for interactive exploration, the gRPC surface is mirrored as
+an OpenAPI 3.1 descriptor generated from the protobuf source of truth.
+
+- **[API Reference](reference.md)** — interactive renderer backed by
+  [Stoplight Elements](https://stoplight.io/open-source/elements). Lets you
+  browse every operation, read its Markdown description, and try it against
+  the configured server.
+- **Protobuf contract** — the source of truth; lives in the [`proto/`](https://github.com/lapc506/payments-core/tree/main/proto)
+  directory of the repository. The OpenAPI descriptor is regenerated from
+  it by the `proto-contract-v1` change.
+
+## Conventions
+
+Every operation documents: its preconditions, its idempotency key, its error
+taxonomy, and which adapter ports it exercises. Breaking changes to the
+contract require a new major version and a migration plan.

--- a/docs/content/docs/api/reference.md
+++ b/docs/content/docs/api/reference.md
@@ -1,0 +1,15 @@
+# API Reference
+
+Interactive renderer for the `payments-core` OpenAPI descriptor. The
+descriptor is mirrored from the protobuf contract in [`proto/`](https://github.com/lapc506/payments-core/tree/main/proto)
+and lives at [`openapi/payments_core.yaml`](https://github.com/lapc506/payments-core/blob/main/openapi/payments_core.yaml).
+Until `proto-contract-v1` lands, only a stub `/health` operation is exposed
+so this page renders without a 404.
+
+<div>
+<elements-api
+  apiDescriptionUrl="/payments-core/openapi/payments_core.yaml"
+  router="hash"
+  layout="sidebar"
+></elements-api>
+</div>

--- a/docs/content/docs/architecture/index.md
+++ b/docs/content/docs/architecture/index.md
@@ -1,0 +1,24 @@
+# Architecture
+
+`payments-core` follows a hexagonal (ports-and-adapters) architecture. The
+domain model knows nothing about Stripe, OnvoPay, TiloPay, dLocal, Revolut,
+Convera, Ripple, or Apple/Google Pay. All those live as adapters on the outside
+edge, behind ports defined in the application layer.
+
+## The layers
+
+- **Domain** — pure types and invariants: `Payment`, `Donation`, `Transfer`,
+  `Refund`, and their state machines. No I/O.
+- **Application** — use-cases that orchestrate domain operations. Defines the
+  port interfaces every adapter must satisfy.
+- **Ports** — abstract interfaces (gRPC-facing on the inbound side, adapter
+  contracts on the outbound side).
+- **Adapters** — concrete implementations: payment providers, wallets, KYC
+  hooks, outbox writers, webhook receivers.
+
+## What lands here
+
+Detailed pages for the domain model, the application layer, and each port
+land with their owning OpenSpec changes (`domain-model-v1`,
+`application-core-v1`, `ports-*`). This index page stays as an orientation
+map; deep-dive pages link from here as they arrive.

--- a/docs/content/docs/donations/index.md
+++ b/docs/content/docs/donations/index.md
@@ -1,0 +1,19 @@
+# Donations & Crowdfunding
+
+`payments-core` treats donations as a first-class flow, distinct from
+commerce payments. Donations have their own state machine (pledge, capture,
+refund-to-donor), their own receipting requirements, and their own fee
+model.
+
+## What lands here
+
+- **Donation state machine** — pledge → captured → settled, with cancel/refund
+  branches. (landing with `donations-domain-v1`)
+- **Provider fit** — which adapters support one-time donations, recurring
+  donations, and tip flows. (landing with `donations-provider-matrix`)
+- **Crowdfunding analysis** — comparison of Vaki / Kickstarter / Indiegogo
+  mechanics against what `payments-core` exposes, and which gaps we plug
+  in-house vs. via partnership. (landing with `donations-crowdfunding`)
+
+Until those pages exist, donation flows are covered inline in each adapter
+proposal under `openspec/changes/`.

--- a/docs/content/docs/governance/index.md
+++ b/docs/content/docs/governance/index.md
@@ -1,0 +1,19 @@
+# Governance
+
+How `payments-core` decides what lands in the repo and what gets rejected.
+
+This section documents the rubric, the change-proposal process, the decision
+log, and the Architectural Decision Records (ADRs) that together form the
+governance layer for the repository. Every OpenSpec change under
+`openspec/changes/` is scored against the rubric before it is accepted.
+
+## What lands here
+
+- **Rubric** — scoring criteria for accepting a change. Lands with
+  `governance-rubric-adoption`.
+- **Decision log** — running record of which changes shipped and why.
+- **ADRs** — one-pager architectural decisions tied to specific changes.
+
+Until those pages exist, the source of truth is the
+[`openspec/changes/`](https://github.com/lapc506/payments-core/tree/main/openspec/changes)
+tree in the repository.

--- a/docs/content/docs/integrations/consumers/index.md
+++ b/docs/content/docs/integrations/consumers/index.md
@@ -1,0 +1,22 @@
+# Consumers
+
+Consumer applications that speak the `payments-core` gRPC contract. Each gets
+a dedicated page once its integration lands. Until then they are listed here
+as plain-text references.
+
+## Product surfaces
+
+- dojo-os — learning platform; uses `payments-core` for tier upgrades, course
+  purchases, and creator payouts.
+- altrupets — pet welfare marketplace; uses `payments-core` for donation
+  flows and marketplace settlements.
+- habitanexus — real-estate connector; uses `payments-core` for deposit and
+  rental collection.
+- vertivolatam — LATAM verticals umbrella; uses `payments-core` for
+  cross-vertical revenue consolidation.
+- aduanext — customs compliance platform; uses `payments-core` for duty-fee
+  collection and agent payouts.
+
+Each consumer page will document: which ports it exercises, which adapters
+it prefers per region, its idempotency strategy, and its failure-handling
+story.

--- a/docs/content/docs/integrations/index.md
+++ b/docs/content/docs/integrations/index.md
@@ -1,0 +1,24 @@
+# Integrations
+
+How `payments-core` plugs into the rest of the `-core` ecosystem and into
+external consumer applications.
+
+## Sibling `-core` services
+
+- **agentic-core** — agent orchestration surface; uses `payments-core` to
+  charge for agent actions and to pay out creator revenue. (landing with
+  `integration-agentic-core`)
+- **marketplace-core** — marketplace primitives (listings, orders); uses
+  `payments-core` for escrow-backed split payments. (landing with
+  `integration-marketplace-core`)
+- **invoice-core** — invoicing + receivables; uses `payments-core` as the
+  collection rail. (landing with `integration-invoice-core`)
+- **compliance-core** — KYC/AML orchestration; `payments-core` calls it via
+  the `KycPort` for high-value transactions. (landing with
+  `integration-compliance-core`)
+
+## Consumer applications
+
+See [Consumers](consumers/index.md) for the five product surfaces that
+currently speak to `payments-core`: dojo-os, altrupets, habitanexus,
+vertivolatam, aduanext.

--- a/docs/content/docs/legal/index.md
+++ b/docs/content/docs/legal/index.md
@@ -1,0 +1,18 @@
+# Legal
+
+Legal artifacts that bind `payments-core` to its consumers and to its
+upstream providers.
+
+## What lands here
+
+- **License** — the repository license, scope, and permitted uses.
+- **Consumer terms** — terms of service presented to downstream applications
+  using the gRPC surface.
+- **Provider agreements** — summaries of the commercial agreements with
+  Stripe, OnvoPay, TiloPay, dLocal, Revolut, Convera, Ripple, Apple, Google
+  (public summaries only; contract specifics stay private).
+- **Data processing** — DPA language for jurisdictions that require it
+  (CR Ley 8968, EU GDPR, etc.).
+
+Until those pages land, the repository root [`LICENSE.md`](https://github.com/lapc506/payments-core/blob/main/LICENSE.md)
+is the canonical license reference.

--- a/docs/content/docs/operations/index.md
+++ b/docs/content/docs/operations/index.md
@@ -1,0 +1,19 @@
+# Operations
+
+Runbooks, deploy topology, and incident response for `payments-core` in
+production.
+
+## What lands here
+
+- **Deploy topology** — where the service runs, how it is scaled, and which
+  regions host adapter-specific traffic.
+- **Observability** — log pipeline, metric dashboards, tracing propagation
+  across consumer → `payments-core` → provider.
+- **Runbooks** — on-call playbooks for adapter outages, webhook backlogs,
+  reconciliation drift, and idempotency-key collisions.
+- **Release process** — how new adapter versions roll out, feature flags,
+  and rollback paths.
+- **SLOs & error budgets** — availability and latency targets per port.
+
+Until those pages land, operational notes live inline in each change's
+`design.md` under the **Risks** section.

--- a/docs/content/docs/ports/index.md
+++ b/docs/content/docs/ports/index.md
@@ -1,0 +1,23 @@
+# Ports
+
+Ports are the abstract seams that keep the domain isolated from providers.
+Each port has one responsibility and a stable contract; adapters plug in on
+the outside.
+
+## Planned ports
+
+- **PaymentProviderPort** — charge / authorize / capture / refund.
+  (landing with `ports-payment-provider`)
+- **DonationProviderPort** — donate / pledge / cancel.
+  (landing with `ports-donation-provider`)
+- **PayoutProviderPort** — disburse to a merchant or beneficiary.
+  (landing with `ports-payout-provider`)
+- **WebhookVerifierPort** — authenticate inbound webhook callbacks.
+  (landing with `ports-webhook-verifier`)
+- **KycPort** — identity verification hooks for high-value operations.
+  (landing with `ports-kyc`)
+- **OutboxPort** — durable, idempotent event publication for consumers.
+  (landing with `ports-outbox`)
+
+Every port page here will document its methods, its error taxonomy, and the
+contract tests adapters must pass.

--- a/docs/content/docs/references/index.md
+++ b/docs/content/docs/references/index.md
@@ -1,0 +1,18 @@
+# References
+
+External sources, standards, and vendor documentation cited across the
+`payments-core` specs. Keeping these in one place avoids duplicated citations
+and makes it easy to audit where a claim came from.
+
+## What lands here
+
+- **Provider documentation** — curated links per adapter (Stripe API,
+  OnvoPay manual, TiloPay integration guide, etc.).
+- **Protocol specs** — gRPC, OpenAPI 3.1, XRPL, ISO 20022 where applicable.
+- **Regulatory references** — LATAM financial-services regulators referenced
+  by compliance-heavy changes.
+- **Books & papers** — hexagonal-architecture, idempotency, exactly-once
+  semantics, and other foundational reads the design borrows from.
+
+Until those pages land, citations live inline in each change's
+`proposal.md` or `design.md`.

--- a/docs/content/docs/security/index.md
+++ b/docs/content/docs/security/index.md
@@ -1,0 +1,21 @@
+# Security
+
+Security posture for `payments-core`. Payments code is a high-value target:
+the bar is higher than for the rest of the ecosystem.
+
+## Scope
+
+- **Secrets management** — how adapter credentials are sourced, rotated, and
+  scoped. (landing with `security-secrets-v1`)
+- **Webhook verification** — signature validation per provider, replay
+  prevention, and timestamp windows. (landing with `security-webhooks-v1`)
+- **Idempotency** — request-level and operation-level guarantees; how
+  duplicate webhook deliveries are collapsed. (landing with
+  `security-idempotency-v1`)
+- **PCI scope** — where card data flows, and why `payments-core` never
+  touches a PAN directly.
+- **Audit + observability** — structured event log and correlation IDs
+  across the request → adapter → provider round trip.
+
+Until those pages land, threat modeling lives inline in each change's
+`design.md`.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,0 +1,40 @@
+# payments-core
+
+One payments sidecar for the `-core` ecosystem. `payments-core` is a gRPC service
+that exposes a uniform payment, donation, and money-movement surface on top of a
+swappable set of adapters (Stripe, OnvoPay, TiloPay, dLocal, Revolut Business,
+Convera, Ripple/XRPL, Apple Pay, Google Pay). Every consumer — `dojo-os`,
+`altrupets`, `habitanexus`, `vertivolatam`, `aduanext` — talks to the same
+contract regardless of the underlying rail.
+
+This site documents the contract, the state machines, the adapters, and the
+integration story. Deep implementation docs live alongside their owning
+OpenSpec changes; this site is the curated, published surface.
+
+## Start here
+
+<div class="grid cards" markdown>
+
+- :material-gavel: **[Governance](docs/governance/index.md)**
+
+    The rubric, decision log, and ADRs that drive what lands in this repo
+    and what gets rejected.
+
+- :material-sitemap: **[Architecture](docs/architecture/index.md)**
+
+    Hexagonal layout: domain, application, ports, and adapters. How the
+    pieces fit, and why the boundary is where it is.
+
+- :material-api: **[API Reference](docs/api/reference.md)**
+
+    Interactive renderer for `openapi/payments_core.yaml` via Stoplight
+    Elements. The gRPC contract mirrored as OpenAPI for readability.
+
+</div>
+
+## Status
+
+`payments-core` is in v0.1 bootstrap. The repository layout, OpenSpec
+processes, and documentation site are being established before the first
+adapter lands. See the [`openspec/changes/`](https://github.com/lapc506/payments-core/tree/main/openspec/changes)
+directory for the current change stack.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,168 @@
+# =============================================================================
+# Material for MkDocs - payments-core documentation
+# Payments sidecar for the -core ecosystem
+# =============================================================================
+
+site_name: payments-core
+site_description: "One payments sidecar for the -core ecosystem — ports, adapters, and contract"
+site_url: https://lapc506.github.io/payments-core
+repo_url: https://github.com/lapc506/payments-core
+repo_name: lapc506/payments-core
+edit_uri: edit/main/docs/content/
+
+docs_dir: content
+site_dir: site
+
+# =============================================================================
+# Theme Configuration
+# =============================================================================
+theme:
+  name: material
+  language: en
+  palette:
+    - scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  font:
+    text: Inter
+    code: JetBrains Mono
+  features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.expand
+    - navigation.path
+    - navigation.top
+    - navigation.indexes
+    - search.highlight
+    - search.share
+    - search.suggest
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+    - content.action.edit
+    - content.action.view
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+    edit: material/pencil
+    view: material/eye
+
+# =============================================================================
+# Plugins
+# =============================================================================
+plugins:
+  - search:
+      lang: en
+  # Optional plugins — require additional pip installs.
+  # Left commented intentionally for v0.1; a future change enables with
+  # a one-line edit + a bump to requirements.txt.
+  # - mermaid2:
+  #     version: 11.4.1
+  #     zoom: true
+  #     theme: base
+  # - git-revision-date-localized:
+  #     enable_creation_date: true
+  # - git-committers:
+  #     repository: lapc506/payments-core
+  # - minify:
+  #     minify_html: true
+
+# =============================================================================
+# Markdown Extensions
+# =============================================================================
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      title: On this page
+  - pymdownx.arithmatex:
+      generic: true
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.critic
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.magiclink:
+      normalize_issue_symbols: true
+      repo_url_shorthand: true
+      user: lapc506
+      repo: payments-core
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.tabbed:
+      alternate_style: true
+      combine_header_slug: true
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+
+# =============================================================================
+# Navigation
+# =============================================================================
+nav:
+  - Home: index.md
+  - Governance: docs/governance/index.md
+  - Architecture: docs/architecture/index.md
+  - Ports: docs/ports/index.md
+  - Adapters: docs/adapters/index.md
+  - Integrations:
+    - Overview: docs/integrations/index.md
+    - Consumers: docs/integrations/consumers/index.md
+  - Donations & Crowdfunding: docs/donations/index.md
+  - Security: docs/security/index.md
+  - API:
+    - Overview: docs/api/index.md
+    - Reference: docs/api/reference.md
+  - References: docs/references/index.md
+  - Legal: docs/legal/index.md
+  - Operations: docs/operations/index.md
+
+# =============================================================================
+# Extra
+# =============================================================================
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/lapc506/payments-core
+  generator: false
+
+dev_addr: 0.0.0.0:8002
+
+extra_css:
+  - assets/stylesheets/payments-core.css
+
+extra_javascript:
+  - assets/javascripts/stoplight-elements.mjs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material>=9.5
+pymdown-extensions>=10.8

--- a/openapi/payments_core.yaml
+++ b/openapi/payments_core.yaml
@@ -1,0 +1,48 @@
+openapi: 3.1.0
+info:
+  title: payments-core
+  version: 0.1.0-stub
+  summary: Placeholder descriptor until proto-contract-v1 lands
+  description: |
+    This is a stub OpenAPI descriptor for `payments-core`. It exposes a single
+    `/health` operation so the documentation site renders the Stoplight
+    Elements embed without a 404. The real descriptor is generated from the
+    protobuf contract in `proto/` by the `proto-contract-v1` change and
+    replaces this file wholesale.
+  license:
+    name: See repository LICENSE.md
+    url: https://github.com/lapc506/payments-core/blob/main/LICENSE.md
+servers:
+  - url: https://api.example.invalid
+    description: Placeholder server; no live endpoint during bootstrap
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      summary: Liveness probe
+      description: |
+        Returns `200 OK` with a constant body. Used by load balancers and
+        orchestrators to confirm the process is running. Replaced by the
+        generated descriptor once `proto-contract-v1` lands.
+      responses:
+        "200":
+          description: Service is alive
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+              examples:
+                ok:
+                  value:
+                    status: ok
+components:
+  schemas:
+    HealthResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          enum: [ok]
+          description: Literal string "ok" when the service is healthy.


### PR DESCRIPTION
## Summary

Bootstraps the published documentation site for `payments-core` and wires [Stoplight Elements](https://stoplight.io/open-source/elements) to render the OpenAPI contract. Implements OpenSpec change [`openspec/changes/mkdocs-site/`](https://github.com/lapc506/payments-core/tree/main/openspec/changes/mkdocs-site) end-to-end.

- **20 files, +610 lines.** Material for MkDocs config mirroring the sibling `aduanext` repo (English, `dev_addr: 0.0.0.0:8002`, pinned `mkdocs-material>=9.5` + `pymdown-extensions>=10.8`). `mermaid2` / `git-revision-date-localized` / `minify` plugins left commented for a future change per v0.1 scope.
- **Landing + 13 section index stubs** (Governance, Architecture, Ports, Adapters, Integrations + Consumers, Donations, Security, API Overview + Reference, References, Legal, Operations). Future topic pages are referenced as plain-text notes, not links, so `mkdocs build --strict` stays green until those pages land.
- **Stoplight Elements** loaded as an ES module (`stoplight-elements.mjs`) via `extra_javascript`. The `.mjs` extension makes MkDocs emit `<script type="module">` automatically, which is required for the `import` statements. `api/reference.md` embeds `<elements-api apiDescriptionUrl="/payments-core/openapi/payments_core.yaml" router="hash" layout="sidebar">`.
- **`openapi/payments_core.yaml`** stub — valid OpenAPI 3.1 with a single `GET /health` operation. Replaced wholesale by the `proto-contract-v1` change.
- **`.github/workflows/docs-deploy.yml`** — on push to `main`, installs Python 3.12 + `docs/requirements.txt`, runs `mkdocs build --strict`, copies `openapi/payments_core.yaml` next to the site output, publishes to `gh-pages` via `peaceiris/actions-gh-pages@v4`.

Closes [DOJ-3292](https://linear.app/dojo-coding/issue/DOJ-3292/payments-core-mkdocs-site-stoplight-elements-for-api-reference).

## Verification

```
$ cd docs && pip install -r requirements.txt && mkdocs build --strict
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: .../docs/site
INFO    -  Documentation built in 0.21 seconds
```

Zero warnings. `/docs/api/reference/index.html` contains the `<elements-api>` element with the expected attributes and the `<script src="..." type="module">` tag pointing at `stoplight-elements.mjs`.

## Test plan

- [ ] CI: docs-deploy workflow triggers on merge to `main` and publishes `gh-pages`.
- [ ] Manual: after first deploy, confirm `https://lapc506.github.io/payments-core/` renders the landing page and `https://lapc506.github.io/payments-core/docs/api/reference/` renders the Stoplight Elements embed with the stub `/health` operation.
- [ ] Manual: set **Settings → Pages → Source** to `gh-pages` branch / root if not auto-enabled.
- [ ] Greptile review resolves to 5/5 before merge.

## Notes

- **Deviation from spec:** the loader file is named `stoplight-elements.mjs` (not `.js`). MkDocs only emits `<script type="module">` for `.mjs` or for explicit `{path, type: module}` dict entries; a plain `.js` file with `import` statements would break at runtime. This matches the `mermaid-init.mjs` convention in `aduanext`.
- **No collision** with DOJ-3291 (repo-bootstrap) or the OpenSpec expansion agent — this PR touches only `docs/`, `openapi/`, and `.github/workflows/docs-deploy.yml`.

Created by Claude Code on behalf of @lapc506

Generated with [Claude Code](https://claude.com/claude-code)