### PR TITLE
Governance-rubric-adoption docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to `payments-core` are recorded here. The format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+- Adopt the ecosystem `-core` governance rubric. The verdict (5 of 5) and
+  the scope boundaries are published at `docs/content/docs/governance/` and
+  captured in the `governance-rubric-adoption` OpenSpec change.

--- a/docs/content/docs/governance/index.md
+++ b/docs/content/docs/governance/index.md
@@ -1,19 +1,96 @@
 # Governance
 
-How `payments-core` decides what lands in the repo and what gets rejected.
+## Why this repository exists
 
-This section documents the rubric, the change-proposal process, the decision
-log, and the Architectural Decision Records (ADRs) that together form the
-governance layer for the repository. Every OpenSpec change under
-`openspec/changes/` is scored against the rubric before it is accepted.
+The `-core` ecosystem shares a single governance rubric that decides when a
+domain justifies a standalone `-core` repository and when it should live as an
+adapter inside an existing `-core`, a module inside one consumer backend, or
+be deferred until the evidence justifies the investment. The rubric is the
+cross-repo artifact; this page is the `payments-core` verdict against it.
 
-## What lands here
+`payments-core` was evaluated on 2026-04-18 and scored **5 of 5**. The
+ecosystem threshold is four. Before this verdict landed, the repository had
+no explicit defence of its own existence — any new contributor had to
+reconstruct the rationale from scattered backend code. That is the gap this
+page closes.
 
-- **Rubric** — scoring criteria for accepting a change. Lands with
-  `governance-rubric-adoption`.
-- **Decision log** — running record of which changes shipped and why.
-- **ADRs** — one-pager architectural decisions tied to specific changes.
+The full decision trail, including the alternatives that were considered and
+rejected, is the OpenSpec change
+[`governance-rubric-adoption`](https://github.com/lapc506/payments-core/tree/main/openspec/changes/governance-rubric-adoption).
+The five criteria themselves are summarised on the [Rubric](rubric.md) page.
 
-Until those pages exist, the source of truth is the
-[`openspec/changes/`](https://github.com/lapc506/payments-core/tree/main/openspec/changes)
-tree in the repository.
+## Verdict
+
+| Criterion | Result | Key evidence |
+|---|:---:|---|
+| 1. Cross-startup reuse | :material-check-all: | Five committed consumers: `dojo-os`, `altrupets-api`, `habitanexus-api`, `vertivolatam-api`, `aduanext-api` |
+| 2. Bounded domain | :material-check: | State machines for PaymentIntent, Subscription, Escrow, Payout, Refund, Dispute are payments-local; `invoice-core` consumes the `PaymentSucceeded` event, it does not own the state |
+| 3. Non-trivial complexity | :material-check-all: | 3DS, webhook HMAC, idempotency, reconciliation, chargebacks, PCI SAQ-A scoping, multi-currency FX, split payments, payout schedules |
+| 4. Credential / regulatory isolation | :material-check-all: | Stripe secrets, OnvoPay keys, Tilopay keys, webhook signing secrets, PCI scope all collapse into the sidecar pod |
+| 5. External integrations with rate-limit / retry | :material-check-all: | Stripe, OnvoPay, Tilopay, dLocal, Revolut, Convera, Ripple, Apple Pay / Google Pay token verification |
+
+Double-check marks (`:material-check-all:`) flag strong passes — the same
+notation used for `compliance-core`, the only other current 5 of 5 in the
+ecosystem.
+
+## Scope boundaries
+
+The verdict is inseparable from what the repository agrees **not** to own.
+Scope creep is the fastest way to invalidate a rubric decision after the
+fact.
+
+**In scope.** PaymentIntent, Subscription, Escrow, Payout, Refund, Dispute,
+Reconciliation, AgenticPayment, FX lookup, WebhookVerifier, Idempotency, and
+Donation (one-time + recurring). Every state machine listed here is owned
+here.
+
+**Out of scope.** Invoice issuance stays in `invoice-core`. KYC and AML stay
+in `compliance-core`. Inventory stays in each consumer backend. Client-side
+SDKs (Apple Pay, Google Pay, `flutter_stripe`) stay in the frontend apps
+that ship them. A standalone Visa Direct adapter is deferred because no
+consumer needs it yet. Crowdfunding is deferred for the reasons captured in
+the
+[`crowdfunding-deferred`](https://github.com/lapc506/payments-core/tree/main/openspec/changes/crowdfunding-deferred)
+change.
+
+## Siblings
+
+`payments-core` is one node of a five-repository ecosystem. Understanding
+how it collaborates with the other four is how a reader knows where to look
+when a concern feels adjacent but is not payments.
+
+- **`agentic-core`** owns AI agent orchestration, memory, and tool routing.
+  It consumes `payments-core` through an `AgenticCheckoutPort` when an agent
+  needs to move money; `payments-core` does not call back into it.
+- **`marketplace-core`** owns catalog, inventory, availability, and
+  traceability. It listens to `PaymentSucceeded` events from `payments-core`
+  to close the loop on an order; the state machines do not overlap.
+- **`invoice-core`** owns fiscal document issuance (CR v4.4, MX retention,
+  CO retention, donation receipts). It listens to `PaymentSucceeded` and
+  emits a comprobante; payment state is not fiscal state.
+- **`compliance-core`** owns KYC, AML, sanctions screening, and audit
+  trails. Above the high-value threshold, `payments-core` gates transactions
+  on a compliance response; compliance does not own the payment state
+  machine either.
+
+## Anti-patterns we avoid
+
+The ecosystem rubric enumerates the failure modes that keep reappearing in
+`-core` proposals. The ones that apply to payments specifically:
+
+- **"It sounds useful, therefore it is a `-core`."** The rubric is the
+  filter that separates well-branded proposals from justified ones.
+- **Theoretical reuse.** A port is added only when a second named consumer
+  needs it in the next 12 to 18 months. `payments-core` shipped with five
+  confirmed consumers; future adapters will be held to the same standard.
+- **Adapter dressed as a domain.** If a candidate only serialises existing
+  state to an external sink, it is an adapter, not a `-core`. An ERP sink
+  for reconciled payments (QuickBooks, Xero, Alegra) lives inside
+  `invoice-core` as an `AccountingSinkPort`; there is no `accounting-core`.
+- **Sidecar for everything.** Sidecars pay for themselves only when all
+  five rubric criteria clear. Utilities, libraries, and backend-local
+  modules are first-class alternatives and should be the default for
+  anything that does not clear the bar.
+- **Premature multi-country breadth.** The adapter set is expanded rail by
+  rail, driven by a named consumer use case, not by "it would be nice to
+  support X eventually."

--- a/docs/content/docs/governance/rubric.md
+++ b/docs/content/docs/governance/rubric.md
@@ -1,0 +1,86 @@
+# Rubric
+
+The five criteria below paraphrase the ecosystem-wide `-core` governance
+rubric. A candidate domain justifies a standalone `-core` repository when it
+clears **four of the five** criteria. `payments-core` cleared all five on
+2026-04-18; the verdict and evidence are on the [Governance](index.md) page.
+
+The canonical ecosystem rubric is authored and maintained outside this
+repository as `2026-04-16-core-governance-rubric.md` by the `-core`
+ecosystem maintainer (@lapc506). When the two documents disagree, the
+canonical version wins and this page is updated to match.
+
+## Criterion 1 — Real cross-startup reuse
+
+At least two consumers in the portfolio need the domain with a similar
+specification on the 12-to-18-month roadmap. The test is **current and
+projectable reuse**, not theoretical reuse. "Some other startup might need
+this eventually" does not count. Building a shared library before a second
+named consumer exists costs more than refactoring the first consumer once
+the second arrives.
+
+## Criterion 2 — Bounded domain
+
+The domain owns its own entities, value objects, ports, state machines, and
+invariants, and it does not collapse into an existing `-core`. The test
+separates a **domain** (with its own ubiquitous language) from a
+**destination adapter** (another way to serialise existing data) or a
+**utility** (shared code without a state machine). Destinations and
+utilities live inside a sibling `-core` or a backend; they do not earn
+their own repository.
+
+## Criterion 3 — Non-trivial complexity
+
+Re-implementing the domain in each consumer backend would consume more than
+roughly 2k lines of **value-bearing** code — algorithms, cryptographic
+protocols, state machines, regulated business rules — excluding CRUD
+boilerplate and serialisation. The heuristic threshold: if a competent
+engineer can replicate the domain in under three days without consulting
+specialised regulation, it probably does not justify a `-core`.
+
+## Criterion 4 — Credential or regulatory isolation
+
+Secrets (`.p12` files, API keys, signing keys) or regulated data (PII, PCI,
+HIPAA, SOC 2, AML-scoped transactions) benefit from running in an isolated
+pod. Isolation buys two things: **operational** (a compliance layer can be
+updated without redeploying every consumer) and **security** (the blast
+radius of a single startup compromise does not reach another startup's
+credentials).
+
+## Criterion 5 — External integrations with rate-limit or retry
+
+The domain depends on external APIs (payment rails, fiscal authorities,
+identity providers, sanctions lists) that benefit from a centralised
+circuit breaker, retry policy, and quota budget. Centralising the traffic
+in one `-core` gives every consumer the same backoff, the same metrics, and
+a single place to coordinate when the upstream degrades.
+
+## How the verdict is applied
+
+For each candidate `-core` the protocol is:
+
+1. Name the candidate.
+2. Score each of the five criteria with :material-check: (pass),
+   :material-alert: (partial), or :material-close: (fail), with a short
+   justification.
+3. Count the passes.
+4. Four or more passes and the candidate is approved; it enters the
+   roadmap. Fewer than four and it is rejected — the decision record
+   captures where the domain lives instead (adapter, backend module,
+   auxiliary library, or deferred).
+5. Approval is a technical verdict only. Implementation priority is set
+   separately against regulatory urgency, consumer blockers, and available
+   build capacity.
+
+A passing verdict is not a licence to expand scope. The [scope
+boundaries](index.md#scope-boundaries) on the Governance page are part of
+the rubric decision; stretching them invalidates the verdict and requires a
+re-evaluation.
+
+## Related reading
+
+- [Governance verdict for `payments-core`](index.md).
+- OpenSpec change:
+  [`governance-rubric-adoption`](https://github.com/lapc506/payments-core/tree/main/openspec/changes/governance-rubric-adoption).
+- Deferred-crowdfunding companion decision:
+  [`crowdfunding-deferred`](https://github.com/lapc506/payments-core/tree/main/openspec/changes/crowdfunding-deferred).

--- a/openspec/changes/governance-rubric-adoption/proposal.md
+++ b/openspec/changes/governance-rubric-adoption/proposal.md
@@ -38,7 +38,7 @@ The same brainstorming session that produced the verdict also produced the decis
 - **Scope boundaries**:
   - **In**: PaymentIntent, Subscription, Escrow, Payout, Refund, Dispute, Reconciliation, AgenticPayment, FX lookup, WebhookVerifier, Idempotency, Donation (one-time + recurring).
   - **Out**: invoice issuance (stays in `invoice-core`), KYC / AML (stays in `compliance-core`), inventory (stays in consumer backends), client-side SDKs (Apple Pay / Google Pay / flutter_stripe — stay in frontend apps), standalone Visa Direct adapter (no consumer today).
-- **Crowdfunding**: deferred. Captured as a separate change (`crowdfunding-diferred`) that documents the Vaki / Coopeservidores collapse and the Kickstarter / Indiegogo alternatives without implementing them. Trigger for re-evaluation is documented.
+- **Crowdfunding**: deferred. Captured as a separate change (`crowdfunding-deferred`) that documents the Vaki / Coopeservidores collapse and the Kickstarter / Indiegogo alternatives without implementing them. Trigger for re-evaluation is documented.
 
 ## Alternatives rejected
 


### PR DESCRIPTION
## Summary

- Publish the reader-facing governance section that documents `payments-core`'s 5-of-5 verdict against the ecosystem `-core` rubric, so the repository's justification is visible outside the OpenSpec change directory.
- Add a paraphrased rubric spec page (`docs/content/docs/governance/rubric.md`) that links back to the canonical ecosystem rubric.
- Seed `CHANGELOG.md` with a single `Unreleased` section tracking this governance adoption.
- Fix the `crowdfunding-diferred` → `crowdfunding-deferred` cross-reference in `openspec/changes/governance-rubric-adoption/proposal.md` so the linked OpenSpec change name matches the on-disk directory (`openspec/changes/crowdfunding-deferred/`).

## OpenSpec change

`openspec/changes/governance-rubric-adoption/` — `proposal.md`, `design.md`, `tasks.md`. This PR implements the `Implementation checklist` and `PR` sections of `tasks.md`.

## Linear

[DOJ-3295](https://linear.app/dojo-coding/issue/DOJ-3295/payments-core-governance-rubric-adoption-docs-page-rubric-spec)

## Verification

- `cd docs && pip install -r requirements.txt && mkdocs build --strict` passes (exit 0, no broken links).
- Governance nav entry (`docs/mkdocs.yml` → `Governance: docs/governance/index.md`) resolves unchanged; `mkdocs.yml` is not modified.
- `docs/content/docs/governance/rubric.md` is reachable via in-page links from the governance index and from `README.md`.
- All intra-repo path references in `openspec/changes/governance-rubric-adoption/` resolve (verified manually).

## Test plan

- [ ] CI `mkdocs` job green.
- [ ] `@greptileai review` at 5/5.
- [ ] Spot-check the rendered governance page on the preview site: verdict table, scope boundaries, siblings, anti-patterns all present.
- [ ] Spot-check that the `Rubric` page reads as orientation for a contributor who has never seen the ecosystem rubric.

Created by Claude Code on behalf of @lapc506