### PR TITLE
Governance-rubric-adoption docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to `payments-core` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+- governance: adopt ecosystem -core rubric verdict (5/5)

--- a/docs/content/docs/governance/index.md
+++ b/docs/content/docs/governance/index.md
@@ -1,19 +1,129 @@
 # Governance
 
-How `payments-core` decides what lands in the repo and what gets rejected.
+`payments-core` is one of several `-core` repositories that share a single
+governance rubric. This page captures the verdict that justifies extracting
+payments as a standalone sidecar, the scope boundaries that keep it focused,
+and the anti-patterns the rubric helps us avoid.
 
-This section documents the rubric, the change-proposal process, the decision
-log, and the Architectural Decision Records (ADRs) that together form the
-governance layer for the repository. Every OpenSpec change under
-`openspec/changes/` is scored against the rubric before it is accepted.
+The authoritative, version-controlled record of this decision lives in the
+[`governance-rubric-adoption`](https://github.com/lapc506/payments-core/tree/main/openspec/changes/governance-rubric-adoption)
+OpenSpec change. This page mirrors it in a reader-friendly format. If the two
+ever disagree, the OpenSpec change wins.
 
-## What lands here
+## Why this repository exists
 
-- **Rubric** — scoring criteria for accepting a change. Lands with
-  `governance-rubric-adoption`.
-- **Decision log** — running record of which changes shipped and why.
-- **ADRs** — one-pager architectural decisions tied to specific changes.
+Before any `-core` repository is created, it must pass a five-criterion rubric
+maintained across the ecosystem. The rubric asks whether the candidate justifies
+its own repo — or whether it would better live as an adapter inside an existing
+`-core`, as a module inside a consumer backend, or as a deferred concern.
 
-Until those pages exist, the source of truth is the
-[`openspec/changes/`](https://github.com/lapc506/payments-core/tree/main/openspec/changes)
-tree in the repository.
+`payments-core` was evaluated on 2026-04-18 and scored **5 of 5**. The rubric
+requires at least 4 of 5 to approve extraction; the minimum-viable ecosystem
+today (`compliance-core`) is the only other repository sharing the same
+5/5 strength bracket. See the [Rubric](rubric.md) page for a paraphrase of the
+five criteria.
+
+## Verdict (2026-04-18)
+
+Score: **5 of 5**.
+
+| Criterion | Result | Key evidence |
+|---|:---:|---|
+| 1. Cross-startup reuse | PASS (strong) | Five committed consumers: `dojo-os`, `altrupets-api`, `habitanexus-api`, `vertivolatam-api`, `aduanext-api` |
+| 2. Bounded domain | PASS | State machines for PaymentIntent, Subscription, Escrow, Payout, Refund, Dispute are all payments-local; `invoice-core` consumes `PaymentSucceeded`, it does not own the state |
+| 3. Non-trivial complexity | PASS (strong) | 3DS, webhook HMAC, idempotency, reconciliation, chargebacks, PCI SAQ-A scoping, multi-currency FX, split payments, payout schedules |
+| 4. Credential / regulatory isolation | PASS (strong) | Stripe secrets, OnvoPay keys, Tilopay keys, webhook signing secrets, and PCI scope all collapse into the sidecar pod |
+| 5. External integrations with rate-limit / retry | PASS (strong) | Stripe, OnvoPay, Tilopay, dLocal, Revolut, Convera, Ripple, Apple Pay / Google Pay token verification |
+
+Full rationale, including rejected alternatives (merging into `invoice-core`,
+leaving payments in each backend, spinning up an `accounting-core` sibling),
+is in the [`proposal.md`](https://github.com/lapc506/payments-core/blob/main/openspec/changes/governance-rubric-adoption/proposal.md)
+of the OpenSpec change.
+
+## Scope boundaries
+
+To keep the rubric meaningful after the fact, the same change freezes what
+belongs in this repo and what does not.
+
+### In scope
+
+- PaymentIntent
+- Subscription (one-time, recurring, upgrade / downgrade)
+- Escrow
+- Payout
+- Refund
+- Dispute
+- Reconciliation
+- AgenticPayment (called from `agentic-core` orchestrations)
+- FX lookup
+- WebhookVerifier
+- Idempotency
+- Donation (one-time and recurring)
+
+### Out of scope
+
+- Invoice issuance — stays in `invoice-core`.
+- KYC / AML — stays in `compliance-core`.
+- Inventory — stays in consumer backends.
+- Client-side SDKs (Apple Pay, Google Pay, `flutter_stripe`) — stay in frontend apps.
+- Standalone Visa Direct adapter — deferred, no consumer today.
+- Crowdfunding — deferred, tracked as a separate change documenting the trigger for re-evaluation.
+
+## Siblings
+
+`payments-core` is one node in a small constellation of sibling `-core`
+repositories. Each owns a bounded context; they collaborate through events and
+explicit ports rather than shared schemas.
+
+- **`agentic-core`** — AI orchestration. Calls `payments-core` through the
+  `AgenticCheckoutPort` when an agent-driven flow needs to move money. Owns
+  nothing about the payment state machine; it only initiates and observes.
+
+- **`invoice-core`** — fiscal documents. Subscribes to `PaymentSucceeded` from
+  `payments-core` and issues the corresponding electronic invoice. ERP export
+  adapters (QuickBooks, Xero, Alegra) live here as `AccountingSinkPort`
+  implementations, not in a separate `accounting-core`.
+
+- **`marketplace-core`** — catalog and traceability. Also subscribes to
+  `PaymentSucceeded` to close the loop between a purchase and the downstream
+  marketplace record. Does not participate in authorization or capture.
+
+- **`compliance-core`** — KYC and AML. Runs before `payments-core` on
+  high-value flows; `payments-core` trusts its verdict and gates accordingly.
+
+Consumer backends (`dojo-os`, `altrupets-api`, `habitanexus-api`,
+`vertivolatam-api`, `aduanext-api`) all talk to `payments-core` through the
+same gRPC sidecar contract; they never embed a Stripe or OnvoPay client
+directly.
+
+## Anti-patterns we avoid
+
+The rubric exists in part to name the failure modes that produce premature
+abstraction. The ones most relevant to a payments repository:
+
+- **Premature abstraction.** A `-core` is only justified when multiple
+  consumers already exist or are imminent. `payments-core` has five committed
+  consumers at the time of extraction.
+- **Reuse theoretical vs actual.** "Someone might want to reuse this" does
+  not clear the rubric. The verdict requires real consumers, each listed by
+  name in the evidence column.
+- **Sidecar for everything.** The sidecar pattern earns its complexity when
+  credential isolation, regulatory scope (PCI), and external integration
+  density all point the same direction. Repositories that fail those tests
+  stay as modules inside a consumer backend.
+- **Destination-sink sibling.** An `accounting-core` that sits downstream of
+  invoices, payments, and inventory is rejected by the rubric: its behavior
+  is better expressed as an export adapter inside `invoice-core`.
+- **Merging domains that share events but not state.** `invoice-core` and
+  `payments-core` share `PaymentSucceeded` but own different state machines
+  and fail on different failure modes. Keeping them separate is a feature,
+  not duplication.
+
+## Related pages
+
+- [Rubric](rubric.md) — paraphrased five criteria with pointers to the
+  canonical ecosystem document.
+- [`proposal.md`](https://github.com/lapc506/payments-core/blob/main/openspec/changes/governance-rubric-adoption/proposal.md)
+  — the OpenSpec change that froze this verdict.
+- [`design.md`](https://github.com/lapc506/payments-core/blob/main/openspec/changes/governance-rubric-adoption/design.md)
+  — the design notes behind this page.

--- a/docs/content/docs/governance/rubric.md
+++ b/docs/content/docs/governance/rubric.md
@@ -1,0 +1,92 @@
+# The `-core` rubric
+
+The rubric below is paraphrased from the ecosystem-wide `-core` governance
+document. That document is the canonical source; it lives outside this
+repository and is maintained by the ecosystem maintainer. This page exists so
+that a reader of `payments-core` can understand what the rubric asks without
+leaving the site.
+
+If this page and the canonical rubric ever disagree, the canonical rubric
+wins. Open a PR against this file to re-sync.
+
+## How the rubric is used
+
+Before a new `-core` repository is created, the candidate is scored against
+five criteria. A score of **4 of 5** or higher is required for approval. The
+scored verdict is then captured in the candidate repo as an OpenSpec change
+(for `payments-core`, see
+[`governance-rubric-adoption`](https://github.com/lapc506/payments-core/tree/main/openspec/changes/governance-rubric-adoption))
+and mirrored on the ecosystem document under its §5.
+
+The same rubric is used in reverse to reject candidates that do not clear the
+bar: when a proposal comes in, the rubric justifies either "yes, extract this"
+or "no, this stays as an adapter / module / deferred concern".
+
+## The five criteria
+
+### 1. Cross-startup reuse
+
+Does the capability have multiple committed consumers today, or in the
+immediate near-term roadmap? A single consumer is never enough; the rubric
+explicitly rejects "someone might want this" as evidence.
+
+Strong evidence looks like a list of specific backends or products, each named
+and with a concrete use case. Weak evidence looks like a generic appeal to
+reusability.
+
+### 2. Bounded domain
+
+Does the capability live inside a coherent bounded context with its own state
+machines, invariants, and vocabulary? If the candidate spans two bounded
+contexts, it is typically better to keep them separate and let events connect
+them.
+
+Strong evidence looks like a list of state machines the candidate owns,
+contrasted with the state machines that neighboring `-core` repositories own.
+
+### 3. Non-trivial complexity
+
+Does the capability carry enough inherent complexity — protocol-level quirks,
+regulatory constraints, failure-mode richness — that extracting it saves
+duplication across consumers?
+
+Strong evidence looks like a list of hard problems the adapter layer must
+solve (idempotency, retries, webhook verification, multi-currency FX, PCI
+scope, dispute handling, etc.).
+
+### 4. Credential / regulatory isolation
+
+Would isolating the capability into its own sidecar meaningfully reduce the
+credential or compliance surface in each consumer? Repositories that collapse
+many secret types and regulatory scopes into a single pod score higher than
+repositories that only hold a handful of generic API keys.
+
+Strong evidence looks like a list of the secrets, regulated data, and audit
+scopes that stop crossing the consumer boundary once the sidecar exists.
+
+### 5. External integrations with rate-limit / retry concerns
+
+Does the capability talk to multiple external services that each impose their
+own rate limits, retry semantics, idempotency requirements, and webhook
+verification rituals? Centralizing those concerns tends to justify the
+sidecar even when the domain itself looks simple.
+
+Strong evidence looks like a list of named external integrations the repo
+plans to adopt, each with its own retry / verification profile.
+
+## Interpreting the score
+
+- **5 of 5** — strong justification; all rubric criteria clearly satisfied.
+  At the time of writing, only `compliance-core` and `payments-core` sit in
+  this bracket.
+- **4 of 5** — approved, with the failing criterion documented as an
+  accepted trade-off.
+- **3 of 5 or lower** — rejected. The candidate should live as an adapter
+  inside an existing `-core`, as a module inside a consumer backend, or be
+  deferred until the rubric changes.
+
+## Anti-patterns the rubric rejects
+
+The ecosystem document lists anti-patterns that the rubric is designed to
+block. The ones most relevant when scoring `payments-core` are paraphrased
+in the [Governance overview](index.md#anti-patterns-we-avoid).

--- a/openspec/changes/governance-rubric-adoption/proposal.md
+++ b/openspec/changes/governance-rubric-adoption/proposal.md
@@ -38,7 +38,7 @@ The same brainstorming session that produced the verdict also produced the decis
 - **Scope boundaries**:
   - **In**: PaymentIntent, Subscription, Escrow, Payout, Refund, Dispute, Reconciliation, AgenticPayment, FX lookup, WebhookVerifier, Idempotency, Donation (one-time + recurring).
   - **Out**: invoice issuance (stays in `invoice-core`), KYC / AML (stays in `compliance-core`), inventory (stays in consumer backends), client-side SDKs (Apple Pay / Google Pay / flutter_stripe — stay in frontend apps), standalone Visa Direct adapter (no consumer today).
-- **Crowdfunding**: deferred. Captured as a separate change (`crowdfunding-diferred`) that documents the Vaki / Coopeservidores collapse and the Kickstarter / Indiegogo alternatives without implementing them. Trigger for re-evaluation is documented.
+- **Crowdfunding**: deferred. Captured as a separate change (`crowdfunding-deferred`) that documents the Vaki / Coopeservidores collapse and the Kickstarter / Indiegogo alternatives without implementing them. Trigger for re-evaluation is documented.
 
 ## Alternatives rejected
 


### PR DESCRIPTION
## Summary

Publish the ecosystem `-core` governance rubric verdict (5/5) as reader-facing MkDocs pages, seed the project changelog, and fix a typo in the OpenSpec proposal.

Backing OpenSpec change: [`governance-rubric-adoption`](https://github.com/lapc506/payments-core/tree/main/openspec/changes/governance-rubric-adoption) — `proposal.md` / `design.md` / `tasks.md`.

## Changes

- `docs/content/docs/governance/index.md` — expand the placeholder into the verdict page per `design.md` §Content outline: why the repo exists, 5x2 verdict table, in/out scope, siblings overview (`agentic-core`, `marketplace-core`, `invoice-core`, `compliance-core`), anti-patterns.
- `docs/content/docs/governance/rubric.md` — paraphrase the five ecosystem rubric criteria with pointers to the canonical (out-of-repo) document.
- `CHANGELOG.md` — new file, single `## Unreleased` entry noting the rubric adoption.
- `openspec/changes/governance-rubric-adoption/proposal.md` — single typo fix: `crowdfunding-diferred` -> `crowdfunding-deferred`.

## Verification

- `mkdocs build --strict` passes (exit 0).
- `docs/mkdocs.yml` nav untouched per hard constraint — the `Governance` entry already points at `docs/governance/index.md` and no broken link was reported by strict mode. `rubric.md` is reachable via an intra-doc link from the governance landing page.
- Scope respected: no edits to `design.md` / `tasks.md`; only the single-character typo fix in `proposal.md`.

## Test plan

- [x] `mkdocs build --strict` — green
- [x] All four files touched are under the declared scope
- [x] No collisions with parallel issues #12 (aduanext) or #13 (proto-contract-v1)

Closes #11

Created by Claude Code on behalf of @lapc506