### PR TITLE
Proto contract v1 (services + events + OpenAPI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,36 @@ jobs:
 
       - name: Test
         run: pnpm test -- --reporter=verbose
+
+  proto:
+    name: proto lint + breaking (buf)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # buf breaking needs history to diff against the main branch.
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: buf lint
+        run: pnpm proto:lint
+
+      # `buf breaking` is skipped on the initial-landing PR because there is
+      # no prior proto state to diff against. It becomes mandatory on
+      # subsequent PRs — remove the `continue-on-error` once this change is
+      # merged to main.
+      - name: buf breaking
+        run: pnpm proto:breaking
+        continue-on-error: true

--- a/docs/content/docs/api/reference.md
+++ b/docs/content/docs/api/reference.md
@@ -3,8 +3,8 @@
 Interactive renderer for the `payments-core` OpenAPI descriptor. The
 descriptor is mirrored from the protobuf contract in [`proto/`](https://github.com/lapc506/payments-core/tree/main/proto)
 and lives at [`openapi/payments_core.yaml`](https://github.com/lapc506/payments-core/blob/main/openapi/payments_core.yaml).
-Until `proto-contract-v1` lands, only a stub `/health` operation is exposed
-so this page renders without a 404.
+It is regenerated from the proto via `pnpm proto:generate`; do not hand-edit
+the YAML.
 
 <div>
 <elements-api

--- a/openapi/payments_core.yaml
+++ b/openapi/payments_core.yaml
@@ -1,48 +1,881 @@
-openapi: 3.1.0
+swagger: "2.0"
 info:
-  title: payments-core
-  version: 0.1.0-stub
-  summary: Placeholder descriptor until proto-contract-v1 lands
-  description: |
-    This is a stub OpenAPI descriptor for `payments-core`. It exposes a single
-    `/health` operation so the documentation site renders the Stoplight
-    Elements embed without a 404. The real descriptor is generated from the
-    protobuf contract in `proto/` by the `proto-contract-v1` change and
-    replaces this file wholesale.
-  license:
-    name: See repository LICENSE.md
-    url: https://github.com/lapc506/payments-core/blob/main/LICENSE.md
-servers:
-  - url: https://api.example.invalid
-    description: Placeholder server; no live endpoint during bootstrap
+  title: lapc506/payments_core/v1/payments_core.proto
+  version: version not set
+tags:
+  - name: PaymentsCore
+consumes:
+  - application/json
+produces:
+  - application/json
 paths:
-  /health:
-    get:
-      operationId: getHealth
-      summary: Liveness probe
-      description: |
-        Returns `200 OK` with a constant body. Used by load balancers and
-        orchestrators to confirm the process is running. Replaced by the
-        generated descriptor once `proto-contract-v1` lands.
+  /lapc506.payments_core.v1.PaymentsCore/CancelSubscription:
+    post:
+      operationId: PaymentsCore_CancelSubscription
       responses:
         "200":
-          description: Service is alive
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/HealthResponse"
-              examples:
-                ok:
-                  value:
-                    status: ok
-components:
-  schemas:
-    HealthResponse:
-      type: object
-      required:
-        - status
-      properties:
-        status:
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1CancelSubscriptionResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1CancelSubscriptionRequest'
+      tags:
+        - PaymentsCore
+  /lapc506.payments_core.v1.PaymentsCore/ConfirmCheckout:
+    post:
+      operationId: PaymentsCore_ConfirmCheckout
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ConfirmCheckoutResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1ConfirmCheckoutRequest'
+      tags:
+        - PaymentsCore
+  /lapc506.payments_core.v1.PaymentsCore/CreatePayout:
+    post:
+      summary: |-
+        ---------------------------------------------------------------------------
+        Payouts
+        ---------------------------------------------------------------------------
+      operationId: PaymentsCore_CreatePayout
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1CreatePayoutResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1CreatePayoutRequest'
+      tags:
+        - PaymentsCore
+  /lapc506.payments_core.v1.PaymentsCore/CreateSubscription:
+    post:
+      summary: |-
+        ---------------------------------------------------------------------------
+        Subscriptions
+        ---------------------------------------------------------------------------
+      operationId: PaymentsCore_CreateSubscription
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1CreateSubscriptionResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1CreateSubscriptionRequest'
+      tags:
+        - PaymentsCore
+  /lapc506.payments_core.v1.PaymentsCore/DisputeEscrow:
+    post:
+      operationId: PaymentsCore_DisputeEscrow
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1DisputeEscrowResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1DisputeEscrowRequest'
+      tags:
+        - PaymentsCore
+  /lapc506.payments_core.v1.PaymentsCore/GetPaymentHistory:
+    post:
+      summary: |-
+        ---------------------------------------------------------------------------
+        Reads
+        ---------------------------------------------------------------------------
+      operationId: PaymentsCore_GetPaymentHistory
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1GetPaymentHistoryResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1GetPaymentHistoryRequest'
+      tags:
+        - PaymentsCore
+  /lapc506.payments_core.v1.PaymentsCore/HoldEscrow:
+    post:
+      summary: |-
+        ---------------------------------------------------------------------------
+        Escrow
+        ---------------------------------------------------------------------------
+      operationId: PaymentsCore_HoldEscrow
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1HoldEscrowResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1HoldEscrowRequest'
+      tags:
+        - PaymentsCore
+  /lapc506.payments_core.v1.PaymentsCore/InitiateAgenticPayment:
+    post:
+      summary: |-
+        ---------------------------------------------------------------------------
+        Agentic commerce (entry point from agentic-core)
+        ---------------------------------------------------------------------------
+      operationId: PaymentsCore_InitiateAgenticPayment
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1InitiateAgenticPaymentResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1InitiateAgenticPaymentRequest'
+      tags:
+        - PaymentsCore
+  /lapc506.payments_core.v1.PaymentsCore/InitiateCheckout:
+    post:
+      summary: |-
+        ---------------------------------------------------------------------------
+        Checkout
+        ---------------------------------------------------------------------------
+      operationId: PaymentsCore_InitiateCheckout
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1InitiateCheckoutResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1InitiateCheckoutRequest'
+      tags:
+        - PaymentsCore
+  /lapc506.payments_core.v1.PaymentsCore/ProcessWebhook:
+    post:
+      summary: |-
+        ---------------------------------------------------------------------------
+        Webhook ingestion (called inbound from gateway-facing HTTP receiver)
+        ---------------------------------------------------------------------------
+      operationId: PaymentsCore_ProcessWebhook
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ProcessWebhookResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1ProcessWebhookRequest'
+      tags:
+        - PaymentsCore
+  /lapc506.payments_core.v1.PaymentsCore/ReconcileDaily:
+    post:
+      operationId: PaymentsCore_ReconcileDaily
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ReconcileDailyResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1ReconcileDailyRequest'
+      tags:
+        - PaymentsCore
+  /lapc506.payments_core.v1.PaymentsCore/RefundPayment:
+    post:
+      operationId: PaymentsCore_RefundPayment
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1RefundPaymentResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1RefundPaymentRequest'
+      tags:
+        - PaymentsCore
+  /lapc506.payments_core.v1.PaymentsCore/ReleaseEscrow:
+    post:
+      operationId: PaymentsCore_ReleaseEscrow
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ReleaseEscrowResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1ReleaseEscrowRequest'
+      tags:
+        - PaymentsCore
+  /lapc506.payments_core.v1.PaymentsCore/SwitchSubscription:
+    post:
+      operationId: PaymentsCore_SwitchSubscription
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1SwitchSubscriptionResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/v1SwitchSubscriptionRequest'
+      tags:
+        - PaymentsCore
+definitions:
+  WalletTokenProvider:
+    type: string
+    enum:
+      - PROVIDER_UNSPECIFIED
+      - PROVIDER_APPLE_PAY
+      - PROVIDER_GOOGLE_PAY
+    default: PROVIDER_UNSPECIFIED
+  protobufAny:
+    type: object
+    properties:
+      '@type':
+        type: string
+    additionalProperties: {}
+  rpcStatus:
+    type: object
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string
+      details:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/protobufAny'
+  v1CancelSubscriptionRequest:
+    type: object
+    properties:
+      subscriptionId:
+        type: string
+      atPeriodEnd:
+        type: boolean
+        description: |-
+          at_period_end = true schedules cancellation for the end of the billing
+          cycle. false cancels immediately.
+      reason:
+        type: string
+      idempotencyKey:
+        type: string
+  v1CancelSubscriptionResponse:
+    type: object
+    properties:
+      subscriptionId:
+        type: string
+      status:
+        $ref: '#/definitions/v1SubscriptionStatus'
+      effectiveAt:
+        type: string
+        format: date-time
+  v1ConfirmCheckoutRequest:
+    type: object
+    properties:
+      intentId:
+        type: string
+      threeDsResult:
+        type: string
+      walletToken:
+        $ref: '#/definitions/v1WalletToken'
+      idempotencyKey:
+        type: string
+  v1ConfirmCheckoutResponse:
+    type: object
+    properties:
+      intentId:
+        type: string
+      status:
+        $ref: '#/definitions/v1PaymentStatus'
+  v1CreatePayoutRequest:
+    type: object
+    properties:
+      consumer:
+        type: string
+      beneficiaryReference:
+        type: string
+        description: |-
+          beneficiary_reference is the caller's identifier for the destination
+          account. payments-core looks up the gateway-side record keyed to this
+          reference (registered out of band for v1).
+      amount:
+        $ref: '#/definitions/v1Money'
+      description:
+        type: string
+      gateway:
+        $ref: '#/definitions/v1GatewayPreference'
+      metadata:
+        type: object
+        additionalProperties:
           type: string
-          enum: [ok]
-          description: Literal string "ok" when the service is healthy.
+      idempotencyKey:
+        type: string
+  v1CreatePayoutResponse:
+    type: object
+    properties:
+      payoutId:
+        type: string
+      status:
+        $ref: '#/definitions/v1PayoutStatus'
+      chosenGateway:
+        $ref: '#/definitions/v1GatewayPreference'
+  v1CreateSubscriptionRequest:
+    type: object
+    properties:
+      consumer:
+        type: string
+      customerReference:
+        type: string
+      planId:
+        type: string
+        description: |-
+          plan_id is an opaque identifier the caller has previously registered
+          with payments-core (out of band for v1). It encodes cadence and amount.
+      gateway:
+        $ref: '#/definitions/v1GatewayPreference'
+      metadata:
+        type: object
+        additionalProperties:
+          type: string
+      idempotencyKey:
+        type: string
+  v1CreateSubscriptionResponse:
+    type: object
+    properties:
+      subscriptionId:
+        type: string
+      status:
+        $ref: '#/definitions/v1SubscriptionStatus'
+      chosenGateway:
+        $ref: '#/definitions/v1GatewayPreference'
+  v1DisputeEscrowRequest:
+    type: object
+    properties:
+      escrowId:
+        type: string
+      reason:
+        type: string
+      evidence:
+        type: array
+        items:
+          type: string
+        description: |-
+          evidence is a list of caller-supplied URLs or document ids describing
+          the dispute. Opaque to payments-core.
+      idempotencyKey:
+        type: string
+  v1DisputeEscrowResponse:
+    type: object
+    properties:
+      escrowId:
+        type: string
+      disputeId:
+        type: string
+      status:
+        $ref: '#/definitions/v1EscrowStatus'
+  v1EscrowStatus:
+    type: string
+    enum:
+      - ESCROW_STATUS_UNSPECIFIED
+      - ESCROW_STATUS_HELD
+      - ESCROW_STATUS_RELEASED
+      - ESCROW_STATUS_DISPUTED
+      - ESCROW_STATUS_REFUNDED
+    default: ESCROW_STATUS_UNSPECIFIED
+    description: EscrowStatus is the lifecycle stage of an escrow hold.
+  v1GatewayPreference:
+    type: string
+    enum:
+      - GATEWAY_PREFERENCE_UNSPECIFIED
+      - GATEWAY_PREFERENCE_AUTO
+      - GATEWAY_PREFERENCE_STRIPE
+      - GATEWAY_PREFERENCE_ONVOPAY
+      - GATEWAY_PREFERENCE_TILOPAY
+      - GATEWAY_PREFERENCE_DLOCAL
+      - GATEWAY_PREFERENCE_REVOLUT
+      - GATEWAY_PREFERENCE_CONVERA
+      - GATEWAY_PREFERENCE_RIPPLE_XRPL
+    default: GATEWAY_PREFERENCE_UNSPECIFIED
+    description: |-
+      GatewayPreference lets callers hint which gateway should handle a request.
+      AUTO (the default) lets payments-core pick based on region, currency, cost,
+      and availability. Adapters for each gateway land in follow-on changes
+      (stripe-adapter-p0, onvopay-adapter-p0, …).
+  v1GetPaymentHistoryRequest:
+    type: object
+    properties:
+      consumer:
+        type: string
+      customerReference:
+        type: string
+      pageSize:
+        type: integer
+        format: int32
+        description: Pagination. page_size defaults to 50 when zero; max 500.
+      pageToken:
+        type: string
+      since:
+        type: string
+        format: date-time
+        description: Optional time window filter. Both inclusive.
+      until:
+        type: string
+        format: date-time
+  v1GetPaymentHistoryResponse:
+    type: object
+    properties:
+      items:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1PaymentHistoryItem'
+      nextPageToken:
+        type: string
+  v1HoldEscrowRequest:
+    type: object
+    properties:
+      consumer:
+        type: string
+      payerReference:
+        type: string
+      payeeReference:
+        type: string
+      amount:
+        $ref: '#/definitions/v1Money'
+      releaseAfter:
+        type: string
+        format: date-time
+        description: |-
+          release_after is a best-effort deadline. Some gateways auto-release; for
+          gateways that do not, payments-core schedules the release.
+      gateway:
+        $ref: '#/definitions/v1GatewayPreference'
+      metadata:
+        type: object
+        additionalProperties:
+          type: string
+      idempotencyKey:
+        type: string
+  v1HoldEscrowResponse:
+    type: object
+    properties:
+      escrowId:
+        type: string
+      status:
+        $ref: '#/definitions/v1EscrowStatus'
+      chosenGateway:
+        $ref: '#/definitions/v1GatewayPreference'
+  v1InitiateAgenticPaymentRequest:
+    type: object
+    properties:
+      consumer:
+        type: string
+      agentId:
+        type: string
+        description: |-
+          agent_id and tool_call_id form the audit trail that links this payment
+          back to the LLM tool call that originated it.
+      toolCallId:
+        type: string
+      auditJwt:
+        type: string
+        description: |-
+          audit_jwt is a scoped JWT minted by agentic-core that proves the user
+          consented to this payment under specific constraints (amount ceiling,
+          merchant allowlist, expiry). payments-core verifies the JWT before
+          charging.
+      customerReference:
+        type: string
+      amount:
+        $ref: '#/definitions/v1Money'
+      description:
+        type: string
+      gateway:
+        $ref: '#/definitions/v1GatewayPreference'
+      metadata:
+        type: object
+        additionalProperties:
+          type: string
+      idempotencyKey:
+        type: string
+  v1InitiateAgenticPaymentResponse:
+    type: object
+    properties:
+      intentId:
+        type: string
+      status:
+        $ref: '#/definitions/v1PaymentStatus'
+      chosenGateway:
+        $ref: '#/definitions/v1GatewayPreference'
+  v1InitiateCheckoutRequest:
+    type: object
+    properties:
+      consumer:
+        type: string
+        description: |-
+          consumer is the tenant tag identifying the caller (e.g. "dojo-os",
+          "altrupets-api"). Used for routing events and for audit.
+      customerReference:
+        type: string
+        description: |-
+          customer_reference is the caller's own identifier for the end user or
+          organization paying. payments-core does not interpret this string.
+      amount:
+        $ref: '#/definitions/v1Money'
+      description:
+        type: string
+      gateway:
+        $ref: '#/definitions/v1GatewayPreference'
+        description: |-
+          gateway hints which provider to use. AUTO (default) lets payments-core
+          choose. If the preference is unavailable, payments-core MAY fall back and
+          the chosen gateway is returned on the response.
+      successUrl:
+        type: string
+        description: |-
+          success_url / cancel_url follow the Stripe redirect model. They are
+          optional for gateways that do not redirect (card-present, wallet-direct).
+      cancelUrl:
+        type: string
+      metadata:
+        type: object
+        additionalProperties:
+          type: string
+        description: |-
+          metadata is free-form key/value pairs the caller can attach for its own
+          bookkeeping. Propagated to emitted events.
+      idempotencyKey:
+        type: string
+        description: |-
+          Required. Enforced by payments-core against a Postgres uniqueness table
+          so retried requests return the same intent.
+  v1InitiateCheckoutResponse:
+    type: object
+    properties:
+      intentId:
+        type: string
+      status:
+        $ref: '#/definitions/v1PaymentStatus'
+      chosenGateway:
+        $ref: '#/definitions/v1GatewayPreference'
+      clientSecret:
+        type: string
+        description: |-
+          client_secret / redirect_url are populated depending on the gateway.
+          client_secret is used by Stripe.js-style SDKs; redirect_url is used by
+          hosted checkout flows.
+      redirectUrl:
+        type: string
+  v1Money:
+    type: object
+    properties:
+      amountMinor:
+        type: string
+        format: int64
+        title: 1234 for $12.34
+      currency:
+        type: string
+        title: ISO 4217, e.g. "USD" / "CRC"
+    description: |-
+      Money is the canonical amount+currency pair used across the ecosystem.
+      `amount_minor` is in the smallest currency unit (cents, céntimos, drops).
+  v1PaymentHistoryItem:
+    type: object
+    properties:
+      intentId:
+        type: string
+      status:
+        $ref: '#/definitions/v1PaymentStatus'
+      amount:
+        $ref: '#/definitions/v1Money'
+      gateway:
+        $ref: '#/definitions/v1GatewayPreference'
+      createdAt:
+        type: string
+        format: date-time
+      metadata:
+        type: object
+        additionalProperties:
+          type: string
+  v1PaymentStatus:
+    type: string
+    enum:
+      - PAYMENT_STATUS_UNSPECIFIED
+      - PAYMENT_STATUS_REQUIRES_ACTION
+      - PAYMENT_STATUS_PROCESSING
+      - PAYMENT_STATUS_SUCCEEDED
+      - PAYMENT_STATUS_FAILED
+      - PAYMENT_STATUS_CANCELED
+      - PAYMENT_STATUS_REFUNDED
+    default: PAYMENT_STATUS_UNSPECIFIED
+    description: |-
+      PaymentStatus is the lifecycle stage of a payment intent. Adapters map their
+      provider-specific statuses onto this canonical set.
+
+       - PAYMENT_STATUS_REQUIRES_ACTION: 3DS / SCA challenge pending
+  v1PayoutStatus:
+    type: string
+    enum:
+      - PAYOUT_STATUS_UNSPECIFIED
+      - PAYOUT_STATUS_PENDING
+      - PAYOUT_STATUS_IN_TRANSIT
+      - PAYOUT_STATUS_PAID
+      - PAYOUT_STATUS_FAILED
+    default: PAYOUT_STATUS_UNSPECIFIED
+    description: PayoutStatus is the lifecycle stage of a payout to a beneficiary.
+  v1ProcessWebhookRequest:
+    type: object
+    properties:
+      gateway:
+        $ref: '#/definitions/v1GatewayPreference'
+        description: gateway tells payments-core which adapter's signature verifier to use.
+      signature:
+        type: string
+        description: signature is the provider's signature header (e.g. Stripe-Signature).
+      payload:
+        type: string
+        format: byte
+        description: |-
+          payload is the raw request body as received. Signature verification is
+          sensitive to any whitespace or encoding change, so this MUST be the
+          bytes that the HTTP receiver saw.
+      receivedAt:
+        type: string
+        format: date-time
+        description: received_at is the ingress timestamp; used for replay-window checks.
+      idempotencyKey:
+        type: string
+  v1ProcessWebhookResponse:
+    type: object
+    properties:
+      eventId:
+        type: string
+      accepted:
+        type: boolean
+  v1ReconcileDailyRequest:
+    type: object
+    properties:
+      date:
+        type: string
+        description: date is the UTC calendar day to reconcile, formatted YYYY-MM-DD.
+      gateway:
+        $ref: '#/definitions/v1GatewayPreference'
+        description: |-
+          gateway scopes the reconciliation to one provider. UNSPECIFIED/AUTO
+          means reconcile across all active gateways.
+  v1ReconcileDailyResponse:
+    type: object
+    properties:
+      date:
+        type: string
+      matchedCount:
+        type: integer
+        format: int32
+      diffs:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1ReconciliationDiff'
+  v1ReconciliationDiff:
+    type: object
+    properties:
+      intentId:
+        type: string
+        description: |-
+          intent_id is present for discrepancies tied to a known local record;
+          empty when the gateway has a ledger entry with no local counterpart.
+      kind:
+        type: string
+        title: |-
+          kind categorizes the discrepancy:
+            "missing_local"    — gateway has a charge we do not
+            "missing_gateway"  — local record with no gateway counterpart
+            "amount_mismatch"  — amounts diverge
+            "status_mismatch"  — statuses diverge
+      expected:
+        $ref: '#/definitions/v1Money'
+      actual:
+        $ref: '#/definitions/v1Money'
+      description:
+        type: string
+  v1RefundPaymentRequest:
+    type: object
+    properties:
+      intentId:
+        type: string
+      amount:
+        $ref: '#/definitions/v1Money'
+        description: |-
+          amount is optional. When absent, the refund is a full refund. When
+          present, it is a partial refund; the adapter validates it does not
+          exceed the charged amount.
+      reason:
+        type: string
+      idempotencyKey:
+        type: string
+  v1RefundPaymentResponse:
+    type: object
+    properties:
+      refundId:
+        type: string
+      status:
+        $ref: '#/definitions/v1PaymentStatus'
+  v1ReleaseEscrowRequest:
+    type: object
+    properties:
+      escrowId:
+        type: string
+      amount:
+        $ref: '#/definitions/v1Money'
+        description: amount is optional; omit to release the full held amount.
+      idempotencyKey:
+        type: string
+  v1ReleaseEscrowResponse:
+    type: object
+    properties:
+      escrowId:
+        type: string
+      status:
+        $ref: '#/definitions/v1EscrowStatus'
+  v1SubscriptionStatus:
+    type: string
+    enum:
+      - SUBSCRIPTION_STATUS_UNSPECIFIED
+      - SUBSCRIPTION_STATUS_ACTIVE
+      - SUBSCRIPTION_STATUS_PAST_DUE
+      - SUBSCRIPTION_STATUS_CANCELED
+      - SUBSCRIPTION_STATUS_PAUSED
+    default: SUBSCRIPTION_STATUS_UNSPECIFIED
+    description: SubscriptionStatus is the lifecycle stage of a subscription.
+  v1SwitchSubscriptionRequest:
+    type: object
+    properties:
+      subscriptionId:
+        type: string
+      newPlanId:
+        type: string
+      prorationBehavior:
+        type: string
+        description: |-
+          proration_behavior controls how mid-period changes are billed. Values
+          are gateway-agnostic: "create_prorations", "none", "always_invoice".
+      idempotencyKey:
+        type: string
+  v1SwitchSubscriptionResponse:
+    type: object
+    properties:
+      subscriptionId:
+        type: string
+      status:
+        $ref: '#/definitions/v1SubscriptionStatus'
+  v1WalletToken:
+    type: object
+    properties:
+      provider:
+        $ref: '#/definitions/WalletTokenProvider'
+      payload:
+        type: string
+        format: byte
+    description: |-
+      WalletToken is the opaque encrypted payload produced by Apple Pay / Google
+      Pay SDKs on the client. payments-core forwards the bytes to the chosen
+      gateway adapter for decryption and charge.

--- a/package.json
+++ b/package.json
@@ -17,14 +17,21 @@
     "format": "prettier -w .",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
-    "clean": "rm -rf dist coverage"
+    "clean": "rm -rf dist coverage",
+    "proto:lint": "buf lint proto",
+    "proto:generate": "buf generate --template proto/buf.gen.yaml proto && mv -f openapi/payments_core.swagger.yaml openapi/payments_core.yaml",
+    "proto:breaking": "buf breaking proto --against '.git#branch=main,subdir=proto'"
   },
   "devDependencies": {
+    "@bufbuild/buf": "^1.45.0",
+    "@grpc/grpc-js": "^1.12.0",
     "@types/node": "^20.11.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "eslint": "^9.0.0",
+    "google-protobuf": "^3.21.4",
     "prettier": "^3.3.0",
+    "ts-proto": "^2.2.0",
     "typescript": "^5.5.0",
     "vitest": "^1.6.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     devDependencies:
+      '@bufbuild/buf':
+        specifier: ^1.45.0
+        version: 1.68.2
+      '@grpc/grpc-js':
+        specifier: ^1.12.0
+        version: 1.14.3
       '@types/node':
         specifier: ^20.11.0
         version: 20.19.39
@@ -20,9 +26,15 @@ importers:
       eslint:
         specifier: ^9.0.0
         version: 9.39.4
+      google-protobuf:
+        specifier: ^3.21.4
+        version: 3.21.4
       prettier:
         specifier: ^3.3.0
         version: 3.8.3
+      ts-proto:
+        specifier: ^2.2.0
+        version: 2.11.6
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
@@ -31,6 +43,56 @@ importers:
         version: 1.6.1(@types/node@20.19.39)
 
 packages:
+
+  '@bufbuild/buf-darwin-arm64@1.68.2':
+    resolution: {integrity: sha512-OCO5/2Rwif8BSB+iTZstYoWP+U3Shof32s9GDh8Q0U0KGOnGsifnrFUZCcmsJw65p3ekOMmlRk5rN0I7QhPCoQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@bufbuild/buf-darwin-x64@1.68.2':
+    resolution: {integrity: sha512-iGhapuptpH2bOxjLkIhbU9zyf81MWo96Q7jvNzsiZsFsE4PPwE02fWoP8Z49YlqS31/sPH5dzpj2DaExgTRQVQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@bufbuild/buf-linux-aarch64@1.68.2':
+    resolution: {integrity: sha512-cSvVYySP/6n6CQhj9x29u1tlnDXLgxhqk4459l/GoMymk7v2NyRbfg90q4Ed2A5kc4UE71jWP6wp7xOseYTOZA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@bufbuild/buf-linux-armv7@1.68.2':
+    resolution: {integrity: sha512-0diz/+EoBd3s6jPbjYu2y6Umyg0wVvzT8LNKo6HlJ+Q5rU4ZfVrMT+tJALpWmE1nQb7evFD2cadaoVXLaFiw9A==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@bufbuild/buf-linux-x64@1.68.2':
+    resolution: {integrity: sha512-Lqhpy+pW0CPrCb341zGnRhjadMT3LDZto7Bwx7Ivik4S0IUUKhFbmZqLkA21Xr2HucKiogUqaDIkINsll1AuFA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@bufbuild/buf-win32-arm64@1.68.2':
+    resolution: {integrity: sha512-p6+kYldQd6xsKTbqFsnMtt9QHFc6SlREB49rS4s4z/gMiEXMx9z2kDT5RLCPOyJK9xZImWSCuNdTQOAiFcHBtg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@bufbuild/buf-win32-x64@1.68.2':
+    resolution: {integrity: sha512-RRroPdgMr73TpZvaM9BZDmoBAd4lgwN6exmE7hH7E8KvDh15McDsQ1Ft9GKWZW/tBY8FTetpI+YkBTRlKih91g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@bufbuild/buf@1.68.2':
+    resolution: {integrity: sha512-kUyc03x0EEubQGA93k4mJFmnybQZtgoMxZeMPoTHxur/XpwweZTe4XCbYA9qDL2DKrC/FnNV7ybGMMmlAvQoBg==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  '@bufbuild/protobuf@2.11.0':
+    resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -208,6 +270,15 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -235,6 +306,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -246,6 +320,36 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
@@ -474,6 +578,10 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -513,6 +621,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  case-anything@2.1.13:
+    resolution: {integrity: sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==}
+    engines: {node: '>=12.13'}
+
   chai@4.5.0:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
     engines: {node: '>=4'}
@@ -523,6 +635,10 @@ packages:
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -557,6 +673,11 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  detect-libc@1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
+
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -565,10 +686,20 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dprint-node@1.0.8:
+    resolution: {integrity: sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -663,6 +794,10 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
@@ -685,6 +820,9 @@ packages:
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
+
+  google-protobuf@3.21.4:
+    resolution: {integrity: sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==}
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -712,6 +850,10 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -759,8 +901,14 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
@@ -884,6 +1032,10 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
+    engines: {node: '>=12.0.0'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -893,6 +1045,10 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -944,6 +1100,14 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
@@ -979,6 +1143,16 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
+
+  ts-poet@6.12.0:
+    resolution: {integrity: sha512-xo+iRNMWqyvXpFTaOAvLPA5QAWO6TZrSUs5s4Odaya3epqofBu/fMLHEWl8jPmjhA0s9sgj9sNvF1BmaQlmQkA==}
+
+  ts-proto-descriptors@2.1.0:
+    resolution: {integrity: sha512-S5EZYEQ6L9KLFfjSRpZWDIXDV/W7tAj8uW7pLsihIxyr62EAVSiKuVPwE8iWnr849Bqa53enex1jhDUcpgquzA==}
+
+  ts-proto@2.11.6:
+    resolution: {integrity: sha512-2rPkH5W/KeXOyVUC6o06RdRabVK8zSDmQpnRz4XbRiYMHRdI12KqDjAdGW7ebxzzMNE5cw/j+ptA0WMVqZILrQ==}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -1077,6 +1251,22 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1086,6 +1276,39 @@ packages:
     engines: {node: '>=12.20'}
 
 snapshots:
+
+  '@bufbuild/buf-darwin-arm64@1.68.2':
+    optional: true
+
+  '@bufbuild/buf-darwin-x64@1.68.2':
+    optional: true
+
+  '@bufbuild/buf-linux-aarch64@1.68.2':
+    optional: true
+
+  '@bufbuild/buf-linux-armv7@1.68.2':
+    optional: true
+
+  '@bufbuild/buf-linux-x64@1.68.2':
+    optional: true
+
+  '@bufbuild/buf-win32-arm64@1.68.2':
+    optional: true
+
+  '@bufbuild/buf-win32-x64@1.68.2':
+    optional: true
+
+  '@bufbuild/buf@1.68.2':
+    optionalDependencies:
+      '@bufbuild/buf-darwin-arm64': 1.68.2
+      '@bufbuild/buf-darwin-x64': 1.68.2
+      '@bufbuild/buf-linux-aarch64': 1.68.2
+      '@bufbuild/buf-linux-armv7': 1.68.2
+      '@bufbuild/buf-linux-x64': 1.68.2
+      '@bufbuild/buf-win32-arm64': 1.68.2
+      '@bufbuild/buf-win32-x64': 1.68.2
+
+  '@bufbuild/protobuf@2.11.0': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -1202,6 +1425,18 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.5
+      yargs: 17.7.2
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -1224,6 +1459,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@js-sdsl/ordered-map@4.4.2': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1235,6 +1472,29 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
@@ -1448,6 +1708,8 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -1479,6 +1741,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  case-anything@2.1.13: {}
+
   chai@4.5.0:
     dependencies:
       assertion-error: 1.1.0
@@ -1497,6 +1761,12 @@ snapshots:
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   color-convert@2.0.1:
     dependencies:
@@ -1524,11 +1794,19 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  detect-libc@1.0.3: {}
+
   diff-sequences@29.6.3: {}
 
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dprint-node@1.0.8:
+    dependencies:
+      detect-libc: 1.0.3
+
+  emoji-regex@8.0.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -1555,6 +1833,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -1681,6 +1961,8 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-caller-file@2.0.5: {}
+
   get-func-name@2.0.2: {}
 
   get-stream@8.0.1: {}
@@ -1704,6 +1986,8 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  google-protobuf@3.21.4: {}
+
   graphemer@1.4.0: {}
 
   has-flag@4.0.0: {}
@@ -1720,6 +2004,8 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -1761,7 +2047,11 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.merge@4.6.2: {}
+
+  long@5.3.2: {}
 
   loupe@2.3.7:
     dependencies:
@@ -1876,11 +2166,28 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
+  protobufjs@7.5.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 20.19.39
+      long: 5.3.2
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
 
   react-is@18.3.1: {}
+
+  require-directory@2.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -1941,6 +2248,16 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
   strip-final-newline@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
@@ -1966,6 +2283,21 @@ snapshots:
   ts-api-utils@1.4.3(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-poet@6.12.0:
+    dependencies:
+      dprint-node: 1.0.8
+
+  ts-proto-descriptors@2.1.0:
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+
+  ts-proto@2.11.6:
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+      case-anything: 2.1.13
+      ts-poet: 6.12.0
+      ts-proto-descriptors: 2.1.0
 
   type-check@0.4.0:
     dependencies:
@@ -2054,6 +2386,26 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 

--- a/proto/buf.gen.yaml
+++ b/proto/buf.gen.yaml
@@ -1,0 +1,43 @@
+# =============================================================================
+# buf.gen.yaml — codegen plugins for payments-core
+# -----------------------------------------------------------------------------
+# Paths are relative to the directory `buf generate` is invoked from (the
+# repo root, via `pnpm proto:generate`), not to this file.
+#
+# Two generated outputs:
+#
+# 1. ts-proto → src/generated/ (gitignored, regenerated on demand).
+#    - outputServices=grpc-js: produces client + server stubs against
+#      @grpc/grpc-js.
+#    - useOptionals=messages: message fields are optional in the generated
+#      TypeScript (matches proto3's implicit-default semantics and avoids
+#      brittle non-null assertions).
+#    - esModuleInterop=true: so the output plays nicely with our ESM config.
+#    - forceLong=string: int64 fields become strings (safe for JSON/JS).
+#
+# 2. openapiv2 → openapi/ (committed as payments_core.yaml after the
+#    post-generate rename step in `pnpm proto:generate`).
+#    - generate_unbound_methods=true: emit every RPC, not just ones with
+#      google.api.http annotations. v1 has no HTTP bindings; this is pure
+#      documentation for Stoplight Elements.
+#    - allow_merge=true + merge_file_name: single consolidated descriptor
+#      covering both proto files.
+#    - output_format=yaml: Stoplight Elements reads yaml natively.
+# =============================================================================
+
+version: v1
+plugins:
+  - plugin: buf.build/community/stephenh-ts-proto
+    out: src/generated
+    opt:
+      - esModuleInterop=true
+      - outputServices=grpc-js
+      - useOptionals=messages
+      - forceLong=string
+  - plugin: buf.build/grpc-ecosystem/openapiv2
+    out: openapi
+    opt:
+      - generate_unbound_methods=true
+      - output_format=yaml
+      - allow_merge=true
+      - merge_file_name=payments_core

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,0 +1,34 @@
+# =============================================================================
+# buf.yaml — lint + breaking config for payments-core proto sources
+# -----------------------------------------------------------------------------
+# Docs: https://buf.build/docs/configuration/v1/buf-yaml
+#
+# - Lint uses the STANDARD preset (the v1 replacement for DEFAULT) minus:
+#     - RPC_REQUEST_STANDARD_NAME / RPC_RESPONSE_STANDARD_NAME: we use
+#       top-level `InitiateCheckoutRequest` / `InitiateCheckoutResponse`
+#       rather than nesting types inside the RPC.
+#     - SERVICE_SUFFIX: the design names the service `PaymentsCore` (not
+#       `PaymentsCoreService`); renaming it is a breaking change for every
+#       generated stub.
+# - Enum zero values must end in `_UNSPECIFIED`.
+# - Breaking uses FILE scope — additive changes allowed within a file, but
+#   a file renamed or removed is breaking. Exercised in CI on every PR
+#   after the initial-landing merge.
+#
+# Proto sources live in the buf-canonical layout
+# (`lapc506/payments_core/v1/`, `lapc506/payments_core/events/v1/`) so the
+# PACKAGE_DIRECTORY_MATCH rule passes without exemption.
+# =============================================================================
+
+version: v1
+lint:
+  use:
+    - STANDARD
+  except:
+    - RPC_REQUEST_STANDARD_NAME
+    - RPC_RESPONSE_STANDARD_NAME
+    - SERVICE_SUFFIX
+  enum_zero_value_suffix: _UNSPECIFIED
+breaking:
+  use:
+    - FILE

--- a/proto/lapc506/payments_core/events/v1/payments_core_events.proto
+++ b/proto/lapc506/payments_core/events/v1/payments_core_events.proto
@@ -1,0 +1,195 @@
+// =============================================================================
+// payments-core v1 — cross-core events
+// -----------------------------------------------------------------------------
+// Typed events emitted to the event bus (Kafka or NATS, decided by the
+// consumer backend). `consumer` is the tenant tag so downstream cores
+// (invoice-core, marketplace-core, altrupets-api) can route by tenant.
+//
+// A separate file is required because events live in a distinct package
+// (`lapc506.payments_core.events.v1`). Proto3 allows at most one package
+// declaration per file, so a single file cannot host both the service and
+// the events.
+//
+// v1 is additive-only once frozen. New events are new messages; existing
+// events do not reshape.
+// =============================================================================
+
+syntax = "proto3";
+
+package lapc506.payments_core.events.v1;
+
+// go_package is required by the openapiv2 generator even though payments-core
+// does not ship a Go binding. Any stable dotted path works; the value is not
+// published.
+option go_package = "github.com/lapc506/payments-core/gen/go/lapc506/payments_core/events/v1;paymentscoreeventsv1";
+
+import "google/protobuf/timestamp.proto";
+import "lapc506/payments_core/v1/payments_core.proto";
+
+// =============================================================================
+// Payment events
+// =============================================================================
+
+message PaymentSucceededEvent {
+  string intent_id = 1;
+  string consumer = 2;
+  lapc506.payments_core.v1.Money amount = 3;
+  lapc506.payments_core.v1.GatewayPreference gateway = 4;
+  google.protobuf.Timestamp occurred_at = 5;
+  map<string, string> metadata = 6;
+}
+
+message PaymentFailedEvent {
+  string intent_id = 1;
+  string consumer = 2;
+  lapc506.payments_core.v1.Money amount = 3;
+  lapc506.payments_core.v1.GatewayPreference gateway = 4;
+  string failure_code = 5;
+  string failure_message = 6;
+  google.protobuf.Timestamp occurred_at = 7;
+  map<string, string> metadata = 8;
+}
+
+message PaymentRefundedEvent {
+  string intent_id = 1;
+  string refund_id = 2;
+  string consumer = 3;
+  lapc506.payments_core.v1.Money amount = 4;
+  lapc506.payments_core.v1.GatewayPreference gateway = 5;
+  string reason = 6;
+  google.protobuf.Timestamp occurred_at = 7;
+  map<string, string> metadata = 8;
+}
+
+message PaymentDisputedEvent {
+  string intent_id = 1;
+  string dispute_id = 2;
+  string consumer = 3;
+  lapc506.payments_core.v1.Money amount = 4;
+  lapc506.payments_core.v1.GatewayPreference gateway = 5;
+  string reason = 6;
+  google.protobuf.Timestamp occurred_at = 7;
+  map<string, string> metadata = 8;
+}
+
+// =============================================================================
+// Subscription events
+// =============================================================================
+
+message SubscriptionActivatedEvent {
+  string subscription_id = 1;
+  string consumer = 2;
+  string customer_reference = 3;
+  string plan_id = 4;
+  lapc506.payments_core.v1.GatewayPreference gateway = 5;
+  google.protobuf.Timestamp occurred_at = 6;
+  map<string, string> metadata = 7;
+}
+
+message SubscriptionPastDueEvent {
+  string subscription_id = 1;
+  string consumer = 2;
+  string customer_reference = 3;
+  lapc506.payments_core.v1.Money amount_due = 4;
+  google.protobuf.Timestamp occurred_at = 5;
+  map<string, string> metadata = 6;
+}
+
+message SubscriptionCanceledEvent {
+  string subscription_id = 1;
+  string consumer = 2;
+  string customer_reference = 3;
+  string reason = 4;
+  bool at_period_end = 5;
+  google.protobuf.Timestamp effective_at = 6;
+  google.protobuf.Timestamp occurred_at = 7;
+  map<string, string> metadata = 8;
+}
+
+// =============================================================================
+// Escrow events
+// =============================================================================
+
+message EscrowHeldEvent {
+  string escrow_id = 1;
+  string consumer = 2;
+  string payer_reference = 3;
+  string payee_reference = 4;
+  lapc506.payments_core.v1.Money amount = 5;
+  lapc506.payments_core.v1.GatewayPreference gateway = 6;
+  google.protobuf.Timestamp occurred_at = 7;
+  map<string, string> metadata = 8;
+}
+
+message EscrowReleasedEvent {
+  string escrow_id = 1;
+  string consumer = 2;
+  lapc506.payments_core.v1.Money amount = 3;
+  google.protobuf.Timestamp occurred_at = 4;
+  map<string, string> metadata = 5;
+}
+
+message EscrowDisputedEvent {
+  string escrow_id = 1;
+  string dispute_id = 2;
+  string consumer = 3;
+  string reason = 4;
+  google.protobuf.Timestamp occurred_at = 5;
+  map<string, string> metadata = 6;
+}
+
+// =============================================================================
+// Payout events
+// =============================================================================
+
+message PayoutIssuedEvent {
+  string payout_id = 1;
+  string consumer = 2;
+  string beneficiary_reference = 3;
+  lapc506.payments_core.v1.Money amount = 4;
+  lapc506.payments_core.v1.GatewayPreference gateway = 5;
+  google.protobuf.Timestamp occurred_at = 6;
+  map<string, string> metadata = 7;
+}
+
+message PayoutFailedEvent {
+  string payout_id = 1;
+  string consumer = 2;
+  string beneficiary_reference = 3;
+  lapc506.payments_core.v1.Money amount = 4;
+  lapc506.payments_core.v1.GatewayPreference gateway = 5;
+  string failure_code = 6;
+  string failure_message = 7;
+  google.protobuf.Timestamp occurred_at = 8;
+  map<string, string> metadata = 9;
+}
+
+// =============================================================================
+// Donation events
+// -----------------------------------------------------------------------------
+// Emitted as typed variants so altrupets-api (and future donation consumers)
+// can subscribe specifically rather than filtering PaymentSucceededEvent by
+// metadata keys.
+// =============================================================================
+
+message DonationReceivedEvent {
+  string intent_id = 1;
+  string consumer = 2;
+  string donor_reference = 3;
+  string cause_reference = 4;
+  lapc506.payments_core.v1.Money amount = 5;
+  lapc506.payments_core.v1.GatewayPreference gateway = 6;
+  google.protobuf.Timestamp occurred_at = 7;
+  map<string, string> metadata = 8;
+}
+
+message RecurringDonationActivatedEvent {
+  string subscription_id = 1;
+  string consumer = 2;
+  string donor_reference = 3;
+  string cause_reference = 4;
+  string plan_id = 5;
+  lapc506.payments_core.v1.GatewayPreference gateway = 6;
+  google.protobuf.Timestamp occurred_at = 7;
+  map<string, string> metadata = 8;
+}

--- a/proto/lapc506/payments_core/v1/payments_core.proto
+++ b/proto/lapc506/payments_core/v1/payments_core.proto
@@ -1,0 +1,506 @@
+// =============================================================================
+// payments-core v1 contract
+// -----------------------------------------------------------------------------
+// One gRPC service (PaymentsCore) + cross-core event messages.
+//
+// Package layout:
+//   - lapc506.payments_core.v1         — service + request/response messages
+//   - lapc506.payments_core.events.v1  — typed events emitted to the bus
+//
+// Hard constraints (see openspec/changes/proto-contract-v1/design.md):
+//   - `idempotency_key` is required on every mutating RPC (field tag 10).
+//   - Gateway selection is an enum field (GatewayPreference), NOT one RPC per
+//     gateway.
+//   - ConfirmCheckoutRequest uses oneof { three_ds_result | wallet_token }.
+//   - v1 is additive-only once frozen. v2 would live in payments_core.v2.proto.
+//
+// The OpenAPI mirror at openapi/payments_core.yaml is regenerated from this
+// file via `pnpm proto:generate`.
+// =============================================================================
+
+syntax = "proto3";
+
+package lapc506.payments_core.v1;
+
+// go_package is required by the openapiv2 generator even though payments-core
+// does not ship a Go binding. Any stable dotted path works; the value is not
+// published.
+option go_package = "github.com/lapc506/payments-core/gen/go/lapc506/payments_core/v1;paymentscorev1";
+
+import "google/protobuf/timestamp.proto";
+
+// =============================================================================
+// Shared value objects
+// =============================================================================
+
+// Money is the canonical amount+currency pair used across the ecosystem.
+// `amount_minor` is in the smallest currency unit (cents, céntimos, drops).
+message Money {
+  int64 amount_minor = 1; // 1234 for $12.34
+  string currency = 2;    // ISO 4217, e.g. "USD" / "CRC"
+}
+
+// GatewayPreference lets callers hint which gateway should handle a request.
+// AUTO (the default) lets payments-core pick based on region, currency, cost,
+// and availability. Adapters for each gateway land in follow-on changes
+// (stripe-adapter-p0, onvopay-adapter-p0, …).
+enum GatewayPreference {
+  GATEWAY_PREFERENCE_UNSPECIFIED = 0;
+  GATEWAY_PREFERENCE_AUTO = 1;
+  GATEWAY_PREFERENCE_STRIPE = 2;
+  GATEWAY_PREFERENCE_ONVOPAY = 3;
+  GATEWAY_PREFERENCE_TILOPAY = 4;
+  GATEWAY_PREFERENCE_DLOCAL = 5;
+  GATEWAY_PREFERENCE_REVOLUT = 6;
+  GATEWAY_PREFERENCE_CONVERA = 7;
+  GATEWAY_PREFERENCE_RIPPLE_XRPL = 8;
+}
+
+// WalletToken is the opaque encrypted payload produced by Apple Pay / Google
+// Pay SDKs on the client. payments-core forwards the bytes to the chosen
+// gateway adapter for decryption and charge.
+message WalletToken {
+  enum Provider {
+    PROVIDER_UNSPECIFIED = 0;
+    PROVIDER_APPLE_PAY = 1;
+    PROVIDER_GOOGLE_PAY = 2;
+  }
+  Provider provider = 1;
+  bytes payload = 2;
+}
+
+// PaymentStatus is the lifecycle stage of a payment intent. Adapters map their
+// provider-specific statuses onto this canonical set.
+enum PaymentStatus {
+  PAYMENT_STATUS_UNSPECIFIED = 0;
+  PAYMENT_STATUS_REQUIRES_ACTION = 1;   // 3DS / SCA challenge pending
+  PAYMENT_STATUS_PROCESSING = 2;
+  PAYMENT_STATUS_SUCCEEDED = 3;
+  PAYMENT_STATUS_FAILED = 4;
+  PAYMENT_STATUS_CANCELED = 5;
+  PAYMENT_STATUS_REFUNDED = 6;
+}
+
+// SubscriptionStatus is the lifecycle stage of a subscription.
+enum SubscriptionStatus {
+  SUBSCRIPTION_STATUS_UNSPECIFIED = 0;
+  SUBSCRIPTION_STATUS_ACTIVE = 1;
+  SUBSCRIPTION_STATUS_PAST_DUE = 2;
+  SUBSCRIPTION_STATUS_CANCELED = 3;
+  SUBSCRIPTION_STATUS_PAUSED = 4;
+}
+
+// EscrowStatus is the lifecycle stage of an escrow hold.
+enum EscrowStatus {
+  ESCROW_STATUS_UNSPECIFIED = 0;
+  ESCROW_STATUS_HELD = 1;
+  ESCROW_STATUS_RELEASED = 2;
+  ESCROW_STATUS_DISPUTED = 3;
+  ESCROW_STATUS_REFUNDED = 4;
+}
+
+// PayoutStatus is the lifecycle stage of a payout to a beneficiary.
+enum PayoutStatus {
+  PAYOUT_STATUS_UNSPECIFIED = 0;
+  PAYOUT_STATUS_PENDING = 1;
+  PAYOUT_STATUS_IN_TRANSIT = 2;
+  PAYOUT_STATUS_PAID = 3;
+  PAYOUT_STATUS_FAILED = 4;
+}
+
+// =============================================================================
+// Service
+// =============================================================================
+
+service PaymentsCore {
+  // ---------------------------------------------------------------------------
+  // Checkout
+  // ---------------------------------------------------------------------------
+  rpc InitiateCheckout(InitiateCheckoutRequest) returns (InitiateCheckoutResponse);
+  rpc ConfirmCheckout(ConfirmCheckoutRequest) returns (ConfirmCheckoutResponse);
+  rpc RefundPayment(RefundPaymentRequest) returns (RefundPaymentResponse);
+
+  // ---------------------------------------------------------------------------
+  // Webhook ingestion (called inbound from gateway-facing HTTP receiver)
+  // ---------------------------------------------------------------------------
+  rpc ProcessWebhook(ProcessWebhookRequest) returns (ProcessWebhookResponse);
+
+  // ---------------------------------------------------------------------------
+  // Subscriptions
+  // ---------------------------------------------------------------------------
+  rpc CreateSubscription(CreateSubscriptionRequest) returns (CreateSubscriptionResponse);
+  rpc SwitchSubscription(SwitchSubscriptionRequest) returns (SwitchSubscriptionResponse);
+  rpc CancelSubscription(CancelSubscriptionRequest) returns (CancelSubscriptionResponse);
+
+  // ---------------------------------------------------------------------------
+  // Escrow
+  // ---------------------------------------------------------------------------
+  rpc HoldEscrow(HoldEscrowRequest) returns (HoldEscrowResponse);
+  rpc ReleaseEscrow(ReleaseEscrowRequest) returns (ReleaseEscrowResponse);
+  rpc DisputeEscrow(DisputeEscrowRequest) returns (DisputeEscrowResponse);
+
+  // ---------------------------------------------------------------------------
+  // Payouts
+  // ---------------------------------------------------------------------------
+  rpc CreatePayout(CreatePayoutRequest) returns (CreatePayoutResponse);
+
+  // ---------------------------------------------------------------------------
+  // Agentic commerce (entry point from agentic-core)
+  // ---------------------------------------------------------------------------
+  rpc InitiateAgenticPayment(InitiateAgenticPaymentRequest) returns (InitiateAgenticPaymentResponse);
+
+  // ---------------------------------------------------------------------------
+  // Reads
+  // ---------------------------------------------------------------------------
+  rpc GetPaymentHistory(GetPaymentHistoryRequest) returns (GetPaymentHistoryResponse);
+  rpc ReconcileDaily(ReconcileDailyRequest) returns (ReconcileDailyResponse);
+}
+
+// =============================================================================
+// Checkout messages
+// =============================================================================
+
+message InitiateCheckoutRequest {
+  // consumer is the tenant tag identifying the caller (e.g. "dojo-os",
+  // "altrupets-api"). Used for routing events and for audit.
+  string consumer = 1;
+
+  // customer_reference is the caller's own identifier for the end user or
+  // organization paying. payments-core does not interpret this string.
+  string customer_reference = 2;
+
+  Money amount = 3;
+  string description = 4;
+
+  // gateway hints which provider to use. AUTO (default) lets payments-core
+  // choose. If the preference is unavailable, payments-core MAY fall back and
+  // the chosen gateway is returned on the response.
+  GatewayPreference gateway = 5;
+
+  // success_url / cancel_url follow the Stripe redirect model. They are
+  // optional for gateways that do not redirect (card-present, wallet-direct).
+  string success_url = 6;
+  string cancel_url = 7;
+
+  // metadata is free-form key/value pairs the caller can attach for its own
+  // bookkeeping. Propagated to emitted events.
+  map<string, string> metadata = 8;
+
+  // Required. Enforced by payments-core against a Postgres uniqueness table
+  // so retried requests return the same intent.
+  string idempotency_key = 10;
+}
+
+message InitiateCheckoutResponse {
+  string intent_id = 1;
+  PaymentStatus status = 2;
+  GatewayPreference chosen_gateway = 3;
+
+  // client_secret / redirect_url are populated depending on the gateway.
+  // client_secret is used by Stripe.js-style SDKs; redirect_url is used by
+  // hosted checkout flows.
+  string client_secret = 4;
+  string redirect_url = 5;
+}
+
+message ConfirmCheckoutRequest {
+  string intent_id = 1;
+
+  // confirmation carries whichever second-leg artifact the gateway needs.
+  // three_ds_result is the opaque token returned by the 3DS challenge; if a
+  // gateway needs a richer multi-leg flow, a follow-on additive RPC
+  // (Initiate3DSChallenge) is added.
+  oneof confirmation {
+    string three_ds_result = 2;
+    WalletToken wallet_token = 3;
+  }
+
+  string idempotency_key = 10;
+}
+
+message ConfirmCheckoutResponse {
+  string intent_id = 1;
+  PaymentStatus status = 2;
+}
+
+message RefundPaymentRequest {
+  string intent_id = 1;
+
+  // amount is optional. When absent, the refund is a full refund. When
+  // present, it is a partial refund; the adapter validates it does not
+  // exceed the charged amount.
+  Money amount = 2;
+
+  string reason = 3;
+
+  string idempotency_key = 10;
+}
+
+message RefundPaymentResponse {
+  string refund_id = 1;
+  PaymentStatus status = 2;
+}
+
+// =============================================================================
+// Webhook messages
+// =============================================================================
+
+message ProcessWebhookRequest {
+  // gateway tells payments-core which adapter's signature verifier to use.
+  GatewayPreference gateway = 1;
+
+  // signature is the provider's signature header (e.g. Stripe-Signature).
+  string signature = 2;
+
+  // payload is the raw request body as received. Signature verification is
+  // sensitive to any whitespace or encoding change, so this MUST be the
+  // bytes that the HTTP receiver saw.
+  bytes payload = 3;
+
+  // received_at is the ingress timestamp; used for replay-window checks.
+  google.protobuf.Timestamp received_at = 4;
+
+  string idempotency_key = 10;
+}
+
+message ProcessWebhookResponse {
+  string event_id = 1;
+  bool accepted = 2;
+}
+
+// =============================================================================
+// Subscription messages
+// =============================================================================
+
+message CreateSubscriptionRequest {
+  string consumer = 1;
+  string customer_reference = 2;
+
+  // plan_id is an opaque identifier the caller has previously registered
+  // with payments-core (out of band for v1). It encodes cadence and amount.
+  string plan_id = 3;
+
+  GatewayPreference gateway = 4;
+  map<string, string> metadata = 5;
+
+  string idempotency_key = 10;
+}
+
+message CreateSubscriptionResponse {
+  string subscription_id = 1;
+  SubscriptionStatus status = 2;
+  GatewayPreference chosen_gateway = 3;
+}
+
+message SwitchSubscriptionRequest {
+  string subscription_id = 1;
+  string new_plan_id = 2;
+
+  // proration_behavior controls how mid-period changes are billed. Values
+  // are gateway-agnostic: "create_prorations", "none", "always_invoice".
+  string proration_behavior = 3;
+
+  string idempotency_key = 10;
+}
+
+message SwitchSubscriptionResponse {
+  string subscription_id = 1;
+  SubscriptionStatus status = 2;
+}
+
+message CancelSubscriptionRequest {
+  string subscription_id = 1;
+
+  // at_period_end = true schedules cancellation for the end of the billing
+  // cycle. false cancels immediately.
+  bool at_period_end = 2;
+
+  string reason = 3;
+
+  string idempotency_key = 10;
+}
+
+message CancelSubscriptionResponse {
+  string subscription_id = 1;
+  SubscriptionStatus status = 2;
+  google.protobuf.Timestamp effective_at = 3;
+}
+
+// =============================================================================
+// Escrow messages
+// =============================================================================
+
+message HoldEscrowRequest {
+  string consumer = 1;
+  string payer_reference = 2;
+  string payee_reference = 3;
+  Money amount = 4;
+
+  // release_after is a best-effort deadline. Some gateways auto-release; for
+  // gateways that do not, payments-core schedules the release.
+  google.protobuf.Timestamp release_after = 5;
+
+  GatewayPreference gateway = 6;
+  map<string, string> metadata = 7;
+
+  string idempotency_key = 10;
+}
+
+message HoldEscrowResponse {
+  string escrow_id = 1;
+  EscrowStatus status = 2;
+  GatewayPreference chosen_gateway = 3;
+}
+
+message ReleaseEscrowRequest {
+  string escrow_id = 1;
+
+  // amount is optional; omit to release the full held amount.
+  Money amount = 2;
+
+  string idempotency_key = 10;
+}
+
+message ReleaseEscrowResponse {
+  string escrow_id = 1;
+  EscrowStatus status = 2;
+}
+
+message DisputeEscrowRequest {
+  string escrow_id = 1;
+  string reason = 2;
+
+  // evidence is a list of caller-supplied URLs or document ids describing
+  // the dispute. Opaque to payments-core.
+  repeated string evidence = 3;
+
+  string idempotency_key = 10;
+}
+
+message DisputeEscrowResponse {
+  string escrow_id = 1;
+  string dispute_id = 2;
+  EscrowStatus status = 3;
+}
+
+// =============================================================================
+// Payout messages
+// =============================================================================
+
+message CreatePayoutRequest {
+  string consumer = 1;
+
+  // beneficiary_reference is the caller's identifier for the destination
+  // account. payments-core looks up the gateway-side record keyed to this
+  // reference (registered out of band for v1).
+  string beneficiary_reference = 2;
+
+  Money amount = 3;
+  string description = 4;
+  GatewayPreference gateway = 5;
+  map<string, string> metadata = 6;
+
+  string idempotency_key = 10;
+}
+
+message CreatePayoutResponse {
+  string payout_id = 1;
+  PayoutStatus status = 2;
+  GatewayPreference chosen_gateway = 3;
+}
+
+// =============================================================================
+// Agentic commerce messages
+// =============================================================================
+
+message InitiateAgenticPaymentRequest {
+  string consumer = 1;
+
+  // agent_id and tool_call_id form the audit trail that links this payment
+  // back to the LLM tool call that originated it.
+  string agent_id = 2;
+  string tool_call_id = 3;
+
+  // audit_jwt is a scoped JWT minted by agentic-core that proves the user
+  // consented to this payment under specific constraints (amount ceiling,
+  // merchant allowlist, expiry). payments-core verifies the JWT before
+  // charging.
+  string audit_jwt = 4;
+
+  string customer_reference = 5;
+  Money amount = 6;
+  string description = 7;
+  GatewayPreference gateway = 8;
+  map<string, string> metadata = 9;
+
+  string idempotency_key = 10;
+}
+
+message InitiateAgenticPaymentResponse {
+  string intent_id = 1;
+  PaymentStatus status = 2;
+  GatewayPreference chosen_gateway = 3;
+}
+
+// =============================================================================
+// Read messages
+// =============================================================================
+
+message GetPaymentHistoryRequest {
+  string consumer = 1;
+  string customer_reference = 2;
+
+  // Pagination. page_size defaults to 50 when zero; max 500.
+  int32 page_size = 3;
+  string page_token = 4;
+
+  // Optional time window filter. Both inclusive.
+  google.protobuf.Timestamp since = 5;
+  google.protobuf.Timestamp until = 6;
+}
+
+message PaymentHistoryItem {
+  string intent_id = 1;
+  PaymentStatus status = 2;
+  Money amount = 3;
+  GatewayPreference gateway = 4;
+  google.protobuf.Timestamp created_at = 5;
+  map<string, string> metadata = 6;
+}
+
+message GetPaymentHistoryResponse {
+  repeated PaymentHistoryItem items = 1;
+  string next_page_token = 2;
+}
+
+message ReconcileDailyRequest {
+  // date is the UTC calendar day to reconcile, formatted YYYY-MM-DD.
+  string date = 1;
+
+  // gateway scopes the reconciliation to one provider. UNSPECIFIED/AUTO
+  // means reconcile across all active gateways.
+  GatewayPreference gateway = 2;
+}
+
+message ReconciliationDiff {
+  // intent_id is present for discrepancies tied to a known local record;
+  // empty when the gateway has a ledger entry with no local counterpart.
+  string intent_id = 1;
+
+  // kind categorizes the discrepancy:
+  //   "missing_local"    — gateway has a charge we do not
+  //   "missing_gateway"  — local record with no gateway counterpart
+  //   "amount_mismatch"  — amounts diverge
+  //   "status_mismatch"  — statuses diverge
+  string kind = 2;
+
+  Money expected = 3;
+  Money actual = 4;
+  string description = 5;
+}
+
+message ReconcileDailyResponse {
+  string date = 1;
+  int32 matched_count = 2;
+  repeated ReconciliationDiff diffs = 3;
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -9,5 +9,9 @@
     "noEmit": false
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "src/generated/**"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["src/generated/**"]
 }


### PR DESCRIPTION
## Summary

Freeze the v1 gRPC contract per [`openspec/changes/proto-contract-v1/`](https://github.com/lapc506/payments-core/tree/main/openspec/changes/proto-contract-v1). Blocks every adapter change and `domain-skeleton` until merged.

## Scope (11 files)

### Proto sources
- `proto/lapc506/payments_core/v1/payments_core.proto` — `service PaymentsCore` with 14 RPCs:
  1. `InitiateCheckout`
  2. `ConfirmCheckout`
  3. `RefundPayment`
  4. `ProcessWebhook`
  5. `CreateSubscription`
  6. `SwitchSubscription`
  7. `CancelSubscription`
  8. `HoldEscrow`
  9. `ReleaseEscrow`
  10. `DisputeEscrow`
  11. `CreatePayout`
  12. `InitiateAgenticPayment`
  13. `GetPaymentHistory`
  14. `ReconcileDaily`
- `proto/lapc506/payments_core/events/v1/payments_core_events.proto` — 14 typed events in `lapc506.payments_core.events.v1`:
  - Payment: `PaymentSucceededEvent`, `PaymentFailedEvent`, `PaymentRefundedEvent`, `PaymentDisputedEvent`
  - Subscription: `SubscriptionActivatedEvent`, `SubscriptionPastDueEvent`, `SubscriptionCanceledEvent`
  - Escrow: `EscrowHeldEvent`, `EscrowReleasedEvent`, `EscrowDisputedEvent`
  - Payout: `PayoutIssuedEvent`, `PayoutFailedEvent`
  - Donation: `DonationReceivedEvent`, `RecurringDonationActivatedEvent`

### Hard constraints satisfied
- `idempotency_key` (field tag 10) is **required** on all 12 mutating RPCs. Read-only RPCs (`GetPaymentHistory`, `ReconcileDaily`) do not carry one.
- Gateway selection is an **enum field** (`GatewayPreference`) with 8 variants: `AUTO`, `STRIPE`, `ONVOPAY`, `TILOPAY`, `DLOCAL`, `REVOLUT`, `CONVERA`, `RIPPLE_XRPL`. Not an RPC split.
- `ConfirmCheckoutRequest` uses `oneof confirmation { string three_ds_result | WalletToken wallet_token }`. `WalletToken.Provider` enum covers Apple Pay and Google Pay.
- `Money` value object (`int64 amount_minor`, `string currency`) is defined once and reused across every amount-bearing message.
- `src/generated/` stays **gitignored** — regenerated on demand. `openapi/payments_core.yaml` IS committed (Stoplight Elements reads it).

### Codegen + tooling
- `proto/buf.yaml` — STANDARD lint (FILE breaking) minus `RPC_REQUEST_STANDARD_NAME`, `RPC_RESPONSE_STANDARD_NAME`, `SERVICE_SUFFIX` (the design names the service `PaymentsCore`, not `PaymentsCoreService`). Enum zero-value suffix enforced.
- `proto/buf.gen.yaml` — ts-proto → `src/generated/` (with `outputServices=grpc-js`, `useOptionals=messages`, `forceLong=string`), openapiv2 → `openapi/payments_core.yaml`.
- `package.json` — new devDeps `@bufbuild/buf`, `ts-proto`, `@grpc/grpc-js`, `google-protobuf`. Scripts `proto:lint`, `proto:generate`, `proto:breaking`.
- `.github/workflows/ci.yml` — new `proto` job runs `buf lint` unconditionally and `buf breaking` as `continue-on-error` (will become mandatory after this PR merges to `main`).

### OpenAPI regen + docs
- `openapi/payments_core.yaml` — replaces the 1-op `/health` stub with the full generated descriptor (881 lines, every RPC, every message). Stoplight Elements on `/api/reference/` now renders the real API.
- `docs/content/docs/api/reference.md` — dropped the "Until proto-contract-v1 lands" note.

### Build hygiene
- `tsconfig.json` / `tsconfig.build.json` — exclude `src/generated/` from strict build. Generated artifacts are regenerated on demand, not part of the source tree that `pnpm build` compiles.

## Local verification

All green on the worktree:

| Check | Result |
|-------|--------|
| `pnpm proto:lint` (buf lint) | pass |
| `pnpm proto:generate` | writes `src/generated/` + `openapi/payments_core.yaml` |
| `pnpm lint` (ESLint) | pass |
| `pnpm build` (tsc) | pass |
| `pnpm test` (vitest) | pass (no suites yet) |
| `mkdocs build --strict` | pass |

## Follow-on changes unblocked

- `domain-skeleton` — consumes the generated TS stubs.
- `stripe-adapter-p0` — implements the first gateway adapter.
- `onvopay-adapter-p0` — implements the second gateway adapter.
- `grpc-server-inbound` — wires `@grpc/grpc-js` server against `PaymentsCore`.

## Deviations from design.md

- Design doc lists the proto as "one file" (`payments_core.proto`). Protobuf's "one package per file" rule forces events into a separate file (`payments_core_events.proto`) since events live in a distinct package (`lapc506.payments_core.events.v1`). Both files live under `proto/` and the issue scope is respected.
- Proto sources use the buf-canonical directory layout (`lapc506/payments_core/v1/`, `lapc506/payments_core/events/v1/`) so the `PACKAGE_DIRECTORY_MATCH` lint rule passes without a further exemption.
- `buf.yaml` uses `STANDARD` instead of the deprecated `DEFAULT` preset name.
- `buf.yaml` adds `SERVICE_SUFFIX` to the `except` list because the design explicitly names the service `PaymentsCore` (not `PaymentsCoreService`).

Closes #13

Created by Claude Code on behalf of @lapc506

🤖 Generated with [Claude Code](https://claude.com/claude-code)