### PR TITLE
OnvoPay adapter (P0) — gateway + recurring + webhook verifier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,14 @@
 # add their required variables here.
 #
 # No values are defined in v0.1: the bootstrap does not wire any runtime yet.
+
+# ---------------------------------------------------------------------------
+# OnvoPay adapter (src/adapters/outbound/gateways/onvopay/)
+# ---------------------------------------------------------------------------
+# Required once the composition root wires OnvoPay into the GatewayRegistry.
+# See docs/content/docs/adapters/onvopay.md for flow details.
+ONVOPAY_API_BASE_URL=https://api.onvopay.com
+ONVOPAY_API_KEY=
+ONVOPAY_WEBHOOK_SIGNING_SECRET=
+ONVOPAY_TIMEOUT_MS=10000
+ONVOPAY_MAX_RETRIES=2

--- a/docs/content/docs/adapters/onvopay.md
+++ b/docs/content/docs/adapters/onvopay.md
@@ -1,0 +1,163 @@
+# OnvoPay adapter
+
+OnvoPay is a Costa-Rican payments gateway specialized in CR-local card
+acquisition. This adapter implements three ports from
+`src/domain/ports/index.ts`:
+
+- `PaymentGatewayPort` — card charges (initiate, confirm, capture, refund)
+- `SubscriptionPort` — recurring charges (`cargos-recurrentes`)
+- `WebhookVerifierPort` — HMAC-SHA256 webhook signature verification
+
+The adapter code lives in `src/adapters/outbound/gateways/onvopay/`. All
+network I/O funnels through a single `OnvoPayHttpClient` (in `client.ts`),
+which centralizes timeouts, retry policy, and auth headers. No other module
+in this adapter imports `node:http` or calls `fetch` directly.
+
+## Environment variables
+
+Configured via `.env` (see `.env.example` for the template):
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `ONVOPAY_API_BASE_URL` | Yes | `https://api.onvopay.com` | Base URL; no trailing slash. |
+| `ONVOPAY_API_KEY` | Yes | — | Secret API key from OnvoPay's dashboard. |
+| `ONVOPAY_WEBHOOK_SIGNING_SECRET` | Yes | — | HMAC secret for webhook verification. |
+| `ONVOPAY_TIMEOUT_MS` | No | `10000` | Per-request timeout. |
+| `ONVOPAY_MAX_RETRIES` | No | `2` | Retries for transient network errors only. |
+
+## Supported currencies
+
+**CRC only at this time.** The adapter enforces this at the gateway boundary
+via `assertOnvoPaySupportedCurrency()` in `mappers.ts`. Non-CRC `Money`
+inputs throw `InvalidMoneyError` before any network call, so consumers see
+a domain-level error rather than a gateway 400.
+
+OnvoPay may support USD or other currencies for specific merchant
+categories; see the Verification Log below for the open `TODO` on this.
+
+## Flows
+
+### Charge
+
+```
+consumer                payments-core           OnvoPay
+    |  CreateCharge         |                      |
+    |---------------------->|                      |
+    |                       | POST /v1/charges     |
+    |                       |--------------------->|
+    |                       |<---------------------|
+    |                       |   { id, status }     |
+    |<----------------------|                      |
+    |   gatewayRef +        |                      |
+    |   requiresAction?     |                      |
+```
+
+If `status === 'requires_action'`, the adapter returns a `ThreeDSChallenge`
+whose opaque payload carries the redirect URL (`next_action.redirect_url`
+or `checkout_url`). Consumers surface the hosted 3DS page; on return, the
+use case layer calls `confirm(...)`.
+
+### Subscription (recurring charges)
+
+```
+POST /v1/subscriptions        { customer, plan, metadata }
+PATCH /v1/subscriptions/:id   { plan, proration_behavior }   // switch
+DELETE /v1/subscriptions/:id                                 // cancel now
+POST /v1/subscriptions/:id/cancel { at_period_end: true }    // cancel at period end
+```
+
+Prorate previews are not yet implemented — the `prorate(...)` method throws
+`ADAPTER_ONVOPAY_NOT_IMPLEMENTED` pending a verified preview endpoint.
+
+### Webhook
+
+The verifier expects `HMAC-SHA256(raw_body, webhook_signing_secret)`
+returned as a lowercase hex digest. Both the bare-hex header shape and the
+composite `t=<unix>,v1=<hex>` shape are accepted.
+
+The verifier:
+
+1. Rejects missing / malformed / wrong-length signatures **before** parsing
+   the body.
+2. Parses the JSON body only after HMAC verification.
+3. Rejects duplicate event ids via a pluggable `OnvoPayWebhookDedupeStore`.
+   Tests use `InMemoryOnvoPayDedupeStore`; production must inject a
+   Redis/Postgres-backed implementation.
+
+## Endpoints used (speculative — see Verification Log)
+
+| Port method | HTTP verb | Path |
+|---|---|---|
+| `PaymentGatewayPort.initiate` | POST | `/v1/charges` |
+| `PaymentGatewayPort.confirm` | POST | `/v1/charges/:id/confirm` |
+| `PaymentGatewayPort.capture` | POST | `/v1/charges/:id/capture` |
+| `PaymentGatewayPort.refund` | POST | `/v1/refunds` |
+| `SubscriptionPort.create` | POST | `/v1/subscriptions` |
+| `SubscriptionPort.switch` | PATCH | `/v1/subscriptions/:id` |
+| `SubscriptionPort.cancel` (immediate) | DELETE | `/v1/subscriptions/:id` |
+| `SubscriptionPort.cancel` (at period end) | POST | `/v1/subscriptions/:id/cancel` |
+
+## Error mapping
+
+| Trigger | Mapped error |
+|---|---|
+| HTTP 401 / 403 | `OnvoPayAuthError` |
+| HTTP 402 | `OnvoPayCardDeclinedError` |
+| HTTP 400 / 422 | `OnvoPayInvalidRequestError` |
+| HTTP 409 | `IdempotencyConflictError` (domain) |
+| HTTP 429 | `OnvoPayRateLimitedError` |
+| HTTP 5xx | `GatewayUnavailableError` (domain) |
+| Network timeout / reset | `GatewayUnavailableError` (domain) |
+
+Business errors (4xx, 5xx) are **never retried** inside the client. Only
+transient network failures are retried, with exponential backoff + jitter,
+up to `ONVOPAY_MAX_RETRIES` attempts.
+
+## Known limitations
+
+- **CRC only.** See Verification Log for the open TODO on multi-currency.
+- **`prorate` not implemented.** Pending a verified preview endpoint.
+- **Escrow / disputes not implemented.** The `EscrowPort` and `DisputePort`
+  will land in a follow-up change (`onvopay-adapter-p1`).
+- **Minor-unit convention for CRC is unverified.** The adapter passes
+  `Money.amountMinor` through as an integer; if OnvoPay expects whole
+  Colones, the conversion lives in `toOnvoPayAmount()` and can be changed
+  without touching port implementations.
+
+## Verification log
+
+This adapter was implemented with `docs.onvopay.com` as a JavaScript-heavy
+SPA that did not render markdown-friendly content via `curl`. Because of
+that, every endpoint shape, field name, error code, and webhook
+convention below should be validated against a live OnvoPay sandbox before
+the adapter is routed production traffic.
+
+- **Baseline commit SHA**: `b359371d9468f04bac84c7f971037b60acf66029`
+  (the tip of `main` at which this adapter was authored).
+- **Docs referenced but not verifiable via plaintext fetch**:
+  - https://docs.onvopay.com/#section/Referencia-API — base URL, auth,
+    idempotency header, charge endpoints, error body shape.
+  - https://docs.onvopay.com/#tag/Cargos-recurrentes — subscription
+    endpoints, proration-behavior enum, cancel-at-period-end flag.
+  - Webhook section (URL not bookmarkable from outside the SPA) —
+    signature algorithm, header name, header shape.
+
+### Open TODOs (search `grep -R "TODO: verify"` in the adapter tree)
+
+| Location | What to verify |
+|---|---|
+| `client.ts` (Bearer header) | Auth scheme — Bearer vs `x-api-key` vs Basic. |
+| `client.ts` (Idempotency-Key header) | Exact header name OnvoPay expects. |
+| `mappers.ts` (CRC-only guard) | Whether USD / EUR are supported. |
+| `mappers.ts` (`toOnvoPayAmount`) | Minor-unit convention for CRC. |
+| `mappers.ts` (status enums) | Complete charge and subscription status sets. |
+| `payment-gateway.ts` (`/v1/charges/:id/confirm`) | Endpoint path for confirmation. |
+| `subscription.ts` (`proration_behavior`) | Enum accepted by the switch endpoint. |
+| `subscription.ts` (`prorate`) | Preview endpoint path and response shape. |
+| `subscription.ts` (`cancel` effectiveAt) | Whether the payload returns `cancel_at`. |
+| `webhook-verifier.ts` (signature scheme) | HMAC algorithm + header name. |
+| `errors.ts` (HTTP 402 mapping) | Whether 402 or 400+code is used for declines. |
+
+Each TODO in code links back to a specific `docs.onvopay.com` section. The
+follow-up work is tracked as a docs-verification issue (link in the PR
+description).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -137,7 +137,9 @@ nav:
   - Governance: docs/governance/index.md
   - Architecture: docs/architecture/index.md
   - Ports: docs/ports/index.md
-  - Adapters: docs/adapters/index.md
+  - Adapters:
+    - Overview: docs/adapters/index.md
+    - OnvoPay: docs/adapters/onvopay.md
   - Integrations:
     - Overview: docs/integrations/index.md
     - Consumers:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -84,6 +84,37 @@ export default [
     },
   },
   {
+    // OnvoPay adapter isolation — the adapter must not reach into sibling
+    // adapters (stripe/, tilopay/, etc.) nor into the inbound gRPC layer.
+    // Allowed dependencies: `src/domain/**`, Node built-ins, and `msw` in
+    // tests. Anything else is a hexagonal boundary violation.
+    files: ['src/adapters/outbound/gateways/onvopay/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: [
+                '**/adapters/outbound/gateways/stripe/**',
+                '**/adapters/outbound/gateways/tilopay/**',
+                '**/adapters/outbound/gateways/dlocal/**',
+                '**/adapters/outbound/gateways/revolut/**',
+                '**/adapters/outbound/gateways/convera/**',
+                '**/adapters/outbound/gateways/ripple_xrpl/**',
+                '**/adapters/inbound/**',
+                '**/application/**',
+                '**/infrastructure/**',
+              ],
+              message:
+                'OnvoPay adapter must not import from sibling adapters, inbound layer, application layer, or infrastructure. Depend on src/domain/** only.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     // Application purity guard — no adapter imports, no gateway-specific SDKs,
     // no direct I/O libraries. The application layer consumes the domain via
     // the `@/domain` barrel (`src/domain/index.ts`) and nothing else.

--- a/src/adapters/outbound/gateways/onvopay/client.ts
+++ b/src/adapters/outbound/gateways/onvopay/client.ts
@@ -131,7 +131,11 @@ export class OnvoPayHttpClient {
     this.apiKey = config.apiKey;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
-    this.fetchImpl = config.fetchImpl ?? fetch;
+    // Bind fetch to globalThis so the method retains its default receiver
+    // when called via `this.fetchImpl(...)`. Native fetch tolerates any
+    // receiver today, but this guards against future spec tightening and
+    // against custom fetchImpls that expect a specific `this`.
+    this.fetchImpl = config.fetchImpl ?? fetch.bind(globalThis);
   }
 
   async request<T>(req: OnvoPayRequest): Promise<T> {

--- a/src/adapters/outbound/gateways/onvopay/client.ts
+++ b/src/adapters/outbound/gateways/onvopay/client.ts
@@ -1,0 +1,228 @@
+// =============================================================================
+// OnvoPay HTTP client
+// -----------------------------------------------------------------------------
+// The ONLY file in this adapter allowed to perform network I/O. Every other
+// file in `src/adapters/outbound/gateways/onvopay/` imports from this module
+// and never calls `fetch` directly. Centralizing the transport here keeps
+// timeouts, retry policy, and auth handling consistent across the charges,
+// subscriptions, and webhook-verification code paths.
+//
+// Dependencies: ONLY Node built-ins. Node 20.11+ ships `fetch`, `Headers`,
+// `AbortSignal.timeout`, and `URL`, so no `axios` / `node-fetch` is needed.
+//
+// Retry policy:
+//   - Transient network errors (ECONNRESET, ETIMEDOUT, aborted fetch) are
+//     retried up to `maxRetries` with exponential backoff + jitter.
+//   - Business errors (4xx and 5xx from OnvoPay) are NEVER retried inside
+//     the client. They surface as `OnvoPayHttpError` and the caller (or the
+//     error mapper) decides how to translate them.
+//   - TanStack-style "the query layer owns retries" does not apply here —
+//     this is a server adapter — but the same principle holds: do not hide
+//     business failures behind transparent retries.
+//
+// Auth: OnvoPay uses a secret API key. The header wire format is
+// `Authorization: Bearer <ONVOPAY_API_KEY>`.
+// TODO: verify against https://docs.onvopay.com/#section/Referencia-API —
+// if the published scheme is `x-api-key` or `Basic`, update `buildHeaders`
+// and keep the `Idempotency-Key` / `Content-Type` lines unchanged.
+// =============================================================================
+
+import { DomainError } from '../../../../domain/errors.js';
+
+// ---------------------------------------------------------------------------
+// Config + errors
+// ---------------------------------------------------------------------------
+
+export interface OnvoPayClientConfig {
+  /**
+   * Base URL, e.g. `https://api.onvopay.com`. No trailing slash.
+   * TODO: verify the exact production base URL against
+   * https://docs.onvopay.com/#section/Referencia-API.
+   */
+  readonly apiBaseUrl: string;
+  /** Secret API key issued by OnvoPay's merchant dashboard. */
+  readonly apiKey: string;
+  /** Per-request timeout, in milliseconds. Default 10_000 if omitted. */
+  readonly timeoutMs?: number;
+  /**
+   * Maximum retry attempts for transient NETWORK errors (not business 4xx/5xx).
+   * Default 2 if omitted. 0 disables retries entirely.
+   */
+  readonly maxRetries?: number;
+  /**
+   * Optional custom fetch. Injected by tests that spin up a local `node:http`
+   * stub instead of using a real network. Production supplies undefined so
+   * the global `fetch` is used.
+   */
+  readonly fetchImpl?: typeof fetch;
+}
+
+export class OnvoPayHttpError extends DomainError {
+  public readonly status: number;
+  public readonly body: string;
+
+  constructor(status: number, message: string, body: string) {
+    super('ADAPTER_ONVOPAY_HTTP', message);
+    this.name = 'OnvoPayHttpError';
+    this.status = status;
+    this.body = body;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class OnvoPayNetworkError extends DomainError {
+  constructor(message: string) {
+    super('ADAPTER_ONVOPAY_NETWORK', message);
+    this.name = 'OnvoPayNetworkError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Request shape
+// ---------------------------------------------------------------------------
+
+export interface OnvoPayRequest {
+  readonly method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  readonly path: string;
+  readonly body?: unknown;
+  /** OnvoPay's idempotency header. Required on mutating calls. */
+  readonly idempotencyKey?: string;
+  /** Query-string parameters; values are URL-encoded at send time. */
+  readonly query?: Readonly<Record<string, string>>;
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_RETRIES = 2;
+const BASE_BACKOFF_MS = 100;
+
+/**
+ * Factory-style constructor; kept as a plain function so the adapter files
+ * depend on the interface rather than on a class constructor.
+ */
+export function createOnvoPayHttpClient(
+  config: OnvoPayClientConfig,
+): OnvoPayHttpClient {
+  return new OnvoPayHttpClient(config);
+}
+
+export class OnvoPayHttpClient {
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+  private readonly timeoutMs: number;
+  private readonly maxRetries: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(config: OnvoPayClientConfig) {
+    if (!config.apiBaseUrl || config.apiBaseUrl.endsWith('/')) {
+      throw new DomainError(
+        'ADAPTER_ONVOPAY_CONFIG',
+        'apiBaseUrl is required and must not end with "/"',
+      );
+    }
+    if (!config.apiKey) {
+      throw new DomainError('ADAPTER_ONVOPAY_CONFIG', 'apiKey is required');
+    }
+    this.baseUrl = config.apiBaseUrl;
+    this.apiKey = config.apiKey;
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+  }
+
+  async request<T>(req: OnvoPayRequest): Promise<T> {
+    const url = this.buildUrl(req.path, req.query);
+    const headers = this.buildHeaders(req.idempotencyKey, req.body !== undefined);
+    const init: RequestInit = { method: req.method, headers };
+    if (req.body !== undefined) {
+      init.body = JSON.stringify(req.body);
+    }
+
+    let lastNetworkErr: unknown = null;
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      try {
+        const response = await this.fetchImpl(url, {
+          ...init,
+          signal: AbortSignal.timeout(this.timeoutMs),
+        });
+        // 204 No Content — OnvoPay signals success with no body on some
+        // endpoints (e.g. subscription cancel). Return null-as-T; callers
+        // that expect a specific shape must tolerate this.
+        if (response.status === 204) {
+          return null as unknown as T;
+        }
+        const raw = await response.text();
+        if (!response.ok) {
+          throw new OnvoPayHttpError(
+            response.status,
+            `OnvoPay ${req.method} ${req.path} failed with HTTP ${response.status}`,
+            raw,
+          );
+        }
+        if (raw.length === 0) {
+          return null as unknown as T;
+        }
+        return JSON.parse(raw) as T;
+      } catch (err) {
+        if (err instanceof OnvoPayHttpError) {
+          // Never retry business errors.
+          throw err;
+        }
+        // Treat everything else (timeout, DNS, connection reset) as transient.
+        lastNetworkErr = err;
+        if (attempt >= this.maxRetries) {
+          break;
+        }
+        await sleep(backoffMs(attempt));
+      }
+    }
+    const msg = lastNetworkErr instanceof Error ? lastNetworkErr.message : 'unknown network error';
+    throw new OnvoPayNetworkError(
+      `OnvoPay ${req.method} ${req.path} failed after ${this.maxRetries + 1} attempt(s): ${msg}`,
+    );
+  }
+
+  private buildUrl(path: string, query?: Readonly<Record<string, string>>): string {
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+    const url = new URL(`${this.baseUrl}${normalizedPath}`);
+    if (query) {
+      for (const [k, v] of Object.entries(query)) {
+        url.searchParams.set(k, v);
+      }
+    }
+    return url.toString();
+  }
+
+  private buildHeaders(idempotencyKey: string | undefined, hasBody: boolean): Headers {
+    const headers = new Headers();
+    // TODO: verify auth scheme against https://docs.onvopay.com/#section/Referencia-API
+    // — if OnvoPay uses `x-api-key: <key>` or `Basic <base64>` instead of
+    // Bearer, change this line (only this file needs updating).
+    headers.set('Authorization', `Bearer ${this.apiKey}`);
+    headers.set('Accept', 'application/json');
+    if (hasBody) {
+      headers.set('Content-Type', 'application/json');
+    }
+    if (idempotencyKey) {
+      // TODO: verify idempotency header name against
+      // https://docs.onvopay.com/#section/Referencia-API — common variants
+      // are `Idempotency-Key`, `X-Idempotency-Key`, and `Onvopay-Idempotency-Key`.
+      headers.set('Idempotency-Key', idempotencyKey);
+    }
+    return headers;
+  }
+}
+
+function backoffMs(attempt: number): number {
+  // Exponential backoff with full jitter: base * 2^attempt * random(0..1).
+  const deterministic = BASE_BACKOFF_MS * Math.pow(2, attempt);
+  return Math.floor(deterministic * Math.random());
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/adapters/outbound/gateways/onvopay/errors.ts
+++ b/src/adapters/outbound/gateways/onvopay/errors.ts
@@ -1,0 +1,110 @@
+// =============================================================================
+// OnvoPay error mapper
+// -----------------------------------------------------------------------------
+// Translates OnvoPay-specific failures (HTTP errors surfaced by `client.ts`,
+// plus generic unknown errors) into `DomainError` subclasses defined in
+// `src/domain/errors.ts`. Keeping the mapping here — rather than in each
+// adapter method — means every port implementation benefits uniformly and the
+// set of adapter-specific error codes stays in one file.
+//
+// The mapping is deliberately coarse; OnvoPay's documented error codes are
+// not exhaustively enumerated and the response body shape is not guaranteed
+// stable. We map by HTTP status class and surface the raw body inside the
+// message so ops can trace the exact failure without needing adapter-local
+// logging.
+//
+// TODO: verify OnvoPay's documented error response schema against
+// https://docs.onvopay.com/#section/Referencia-API — if they publish a
+// `{ code, message, doc_url }` envelope, add a thin parse step here so the
+// mapped error carries the OnvoPay-side error code in a structured field.
+// =============================================================================
+
+import { DomainError, GatewayUnavailableError, IdempotencyConflictError } from '../../../../domain/errors.js';
+import { OnvoPayHttpError, OnvoPayNetworkError } from './client.js';
+
+export class OnvoPayCardDeclinedError extends DomainError {
+  constructor(message: string) {
+    super('ADAPTER_ONVOPAY_CARD_DECLINED', message);
+    this.name = 'OnvoPayCardDeclinedError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class OnvoPayAuthError extends DomainError {
+  constructor(message: string) {
+    super('ADAPTER_ONVOPAY_AUTH', message);
+    this.name = 'OnvoPayAuthError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class OnvoPayInvalidRequestError extends DomainError {
+  constructor(message: string) {
+    super('ADAPTER_ONVOPAY_INVALID_REQUEST', message);
+    this.name = 'OnvoPayInvalidRequestError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class OnvoPayRateLimitedError extends DomainError {
+  constructor(message: string) {
+    super('ADAPTER_ONVOPAY_RATE_LIMITED', message);
+    this.name = 'OnvoPayRateLimitedError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Map a caught error into a DomainError subclass. Never throws. Always
+ * returns a mapped error that the caller can re-throw.
+ */
+export function mapOnvoPayError(err: unknown): DomainError {
+  if (err instanceof OnvoPayHttpError) {
+    switch (err.status) {
+      case 401:
+      case 403:
+        return new OnvoPayAuthError(
+          `OnvoPay authentication failed (${err.status}): ${err.body}`,
+        );
+      case 402:
+        // TODO: verify against https://docs.onvopay.com/ — OnvoPay may use
+        // 400 + a specific error code instead of HTTP 402 for declines.
+        return new OnvoPayCardDeclinedError(`OnvoPay card declined: ${err.body}`);
+      case 409:
+        return new IdempotencyConflictError(
+          `OnvoPay reported idempotency conflict: ${err.body}`,
+        );
+      case 400:
+      case 422:
+        return new OnvoPayInvalidRequestError(
+          `OnvoPay rejected request (${err.status}): ${err.body}`,
+        );
+      case 429:
+        return new OnvoPayRateLimitedError(
+          `OnvoPay rate limit hit: ${err.body}`,
+        );
+      case 500:
+      case 502:
+      case 503:
+      case 504:
+        return new GatewayUnavailableError(
+          'onvopay',
+          `HTTP ${err.status}: ${err.body}`,
+        );
+      default:
+        return new DomainError(
+          'ADAPTER_ONVOPAY_UNKNOWN',
+          `Unmapped OnvoPay HTTP ${err.status}: ${err.body}`,
+        );
+    }
+  }
+  if (err instanceof OnvoPayNetworkError) {
+    return new GatewayUnavailableError('onvopay', err.message);
+  }
+  if (err instanceof DomainError) {
+    // Already a domain error — pass through without double-wrapping.
+    return err;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return new DomainError('ADAPTER_ONVOPAY_UNKNOWN', `Unexpected OnvoPay error: ${message}`);
+}

--- a/src/adapters/outbound/gateways/onvopay/index.ts
+++ b/src/adapters/outbound/gateways/onvopay/index.ts
@@ -1,0 +1,56 @@
+// =============================================================================
+// OnvoPay adapter barrel
+// -----------------------------------------------------------------------------
+// Single import surface for the composition root. Consumers wire the OnvoPay
+// gateway into `GatewayRegistry` by importing from this file; nothing else
+// should reach into individual module files.
+//
+// Hard constraint (enforced by ESLint `no-restricted-imports` on
+// `src/adapters/outbound/gateways/onvopay/**`): no sibling adapter imports.
+// This adapter depends only on:
+//   - `src/domain/**`           (ports, entities, value objects, errors)
+//   - Node built-ins            (`node:crypto` for HMAC, `node:http` in tests)
+//   - `msw` (test-only)
+// =============================================================================
+
+export {
+  OnvoPayHttpClient,
+  createOnvoPayHttpClient,
+  OnvoPayHttpError,
+  OnvoPayNetworkError,
+  type OnvoPayClientConfig,
+  type OnvoPayRequest,
+} from './client.js';
+
+export {
+  mapOnvoPayError,
+  OnvoPayAuthError,
+  OnvoPayCardDeclinedError,
+  OnvoPayInvalidRequestError,
+  OnvoPayRateLimitedError,
+} from './errors.js';
+
+export {
+  assertOnvoPaySupportedCurrency,
+  toConfirmStatus,
+  toGatewayRef,
+  toOnvoPayAmount,
+  toSubscriptionProjection,
+  toSubscriptionStatus,
+  type OnvoPayCharge,
+  type OnvoPayRefund,
+  type OnvoPaySubscription,
+  type OnvoPayWebhookEvent,
+} from './mappers.js';
+
+export { OnvoPayPaymentGateway } from './payment-gateway.js';
+export { OnvoPaySubscriptionGateway } from './subscription.js';
+
+export {
+  InMemoryOnvoPayDedupeStore,
+  OnvoPayWebhookVerifier,
+  WebhookDuplicateEventError,
+  WebhookSignatureError,
+  type OnvoPayWebhookDedupeStore,
+  type OnvoPayWebhookVerifierConfig,
+} from './webhook-verifier.js';

--- a/src/adapters/outbound/gateways/onvopay/mappers.ts
+++ b/src/adapters/outbound/gateways/onvopay/mappers.ts
@@ -1,0 +1,197 @@
+// =============================================================================
+// OnvoPay <-> domain mappers
+// -----------------------------------------------------------------------------
+// OnvoPay's wire format (JSON over HTTPS) is translated into domain types
+// here and here only. No other file in this adapter constructs domain objects
+// from a raw OnvoPay payload; they all call `toDomain*` helpers below.
+//
+// Currency note: OnvoPay's primary market is Costa Rica, where the Colón
+// (CRC) has no practical minor unit (subdivision is notional). The adapter
+// forbids non-CRC charges at the gateway boundary so consumers don't
+// accidentally route a USD payment through OnvoPay and get a 400 from the
+// gateway after the use case has already committed an intent.
+//
+// TODO: verify against https://docs.onvopay.com/#section/Referencia-API —
+// if OnvoPay supports USD, EUR, or multi-currency settlement for specific
+// merchants, relax `assertCrcOnly()` and document which currencies are
+// accepted in docs/content/docs/adapters/onvopay.md.
+// =============================================================================
+
+import { InvalidMoneyError } from '../../../../domain/errors.js';
+import type { GatewayRef } from '../../../../domain/value_objects/opaque-refs.js';
+import type { Money } from '../../../../domain/value_objects/money.js';
+import type { Subscription, SubscriptionStatus } from '../../../../domain/entities/subscription.js';
+
+// ---------------------------------------------------------------------------
+// OnvoPay wire types (reverse-modeled from the docs at time of writing)
+// ---------------------------------------------------------------------------
+
+/**
+ * OnvoPay charge resource. Field shapes are reverse-modeled from
+ * https://docs.onvopay.com/#section/Referencia-API — every field is marked
+ * with a TODO until verified against a live sandbox response.
+ */
+export interface OnvoPayCharge {
+  /** Charge id, e.g. `chr_abc123`. */
+  readonly id: string;
+  /** Integer amount in the currency's minor unit. */
+  readonly amount: number;
+  /** ISO-4217 currency, typically `CRC` or `USD`. */
+  readonly currency: string;
+  /**
+   * Status string. Likely values (TODO: verify):
+   * `pending` | `requires_action` | `succeeded` | `failed` | `refunded`.
+   */
+  readonly status: string;
+  /** URL that hosts a 3DS / redirect challenge, when `status === 'requires_action'`. */
+  readonly checkout_url?: string;
+  /** Optional structured next-action, gateway-specific. */
+  readonly next_action?: { readonly redirect_url?: string } | null;
+  /** Failure reason when status is `failed`. */
+  readonly failure_reason?: string | null;
+}
+
+export interface OnvoPaySubscription {
+  readonly id: string;
+  readonly status: string;
+  readonly plan_id?: string;
+  readonly customer_id?: string;
+}
+
+export interface OnvoPayRefund {
+  readonly id: string;
+  readonly status: string;
+  readonly amount?: number;
+  readonly currency?: string;
+  readonly charge_id?: string;
+}
+
+/**
+ * OnvoPay webhook event envelope. TODO: verify field names against
+ * https://docs.onvopay.com/ webhook section. Some gateways nest payload
+ * under `data.object`; OnvoPay may use `data` or `resource` instead.
+ */
+export interface OnvoPayWebhookEvent {
+  readonly id: string;
+  readonly type: string;
+  readonly created_at?: string;
+  readonly data?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Outbound: domain -> OnvoPay wire
+// ---------------------------------------------------------------------------
+
+/**
+ * Guard that enforces the OnvoPay CRC-only contract at the adapter boundary.
+ * Throws InvalidMoneyError for any other currency so consumers see a
+ * domain-level error rather than a gateway 400.
+ *
+ * TODO: verify OnvoPay's full supported-currency list. If USD (or any other
+ * currency) is supported, widen this guard accordingly.
+ */
+export function assertOnvoPaySupportedCurrency(money: Money): void {
+  if (money.currency !== 'CRC') {
+    throw new InvalidMoneyError(
+      `OnvoPay adapter only supports CRC at this time; got '${money.currency}'. ` +
+        `Route non-CRC payments through a different gateway.`,
+    );
+  }
+}
+
+/**
+ * Serialize a `Money` into the OnvoPay charge body shape. OnvoPay's minor-unit
+ * convention for CRC is not explicitly documented; we pass the integer
+ * amount through unchanged and expect the gateway to interpret it as
+ * "minor units" per industry convention.
+ *
+ * TODO: verify minor-unit convention for CRC against
+ * https://docs.onvopay.com/#section/Referencia-API — if OnvoPay expects
+ * whole Colones (amount/100) instead of minor units, change the conversion
+ * here and nowhere else.
+ */
+export function toOnvoPayAmount(money: Money): number {
+  assertOnvoPaySupportedCurrency(money);
+  const n = Number(money.amountMinor);
+  if (!Number.isFinite(n) || n < 0) {
+    throw new InvalidMoneyError(
+      `Amount ${money.amountMinor.toString()} is not representable as a JSON number`,
+    );
+  }
+  return n;
+}
+
+// ---------------------------------------------------------------------------
+// Inbound: OnvoPay wire -> domain
+// ---------------------------------------------------------------------------
+
+export function toGatewayRef(onvopayId: string): GatewayRef {
+  return { gateway: 'onvopay', externalId: onvopayId };
+}
+
+/**
+ * Map OnvoPay charge status to the discriminator expected by
+ * `ConfirmPaymentResult.status`. Unknown statuses degrade to 'failed' so
+ * the use case layer can still emit a terminal event; the raw OnvoPay
+ * status is preserved in `failureReason` for operators.
+ *
+ * TODO: verify complete status enum against
+ * https://docs.onvopay.com/#section/Referencia-API.
+ */
+export function toConfirmStatus(
+  onvopayStatus: string,
+): 'succeeded' | 'failed' | 'requires_action' {
+  switch (onvopayStatus) {
+    case 'succeeded':
+    case 'captured':
+      return 'succeeded';
+    case 'requires_action':
+    case 'pending_confirmation':
+      return 'requires_action';
+    default:
+      return 'failed';
+  }
+}
+
+/**
+ * Map OnvoPay subscription status onto the domain Subscription state
+ * machine. Any unmapped status becomes 'incomplete' rather than 'canceled'
+ * because a subscription that shows up with an unknown status should be
+ * treated as recoverable until explicitly canceled by the gateway.
+ *
+ * TODO: verify status enum against
+ * https://docs.onvopay.com/#tag/Cargos-recurrentes.
+ */
+export function toSubscriptionStatus(onvopayStatus: string): SubscriptionStatus {
+  switch (onvopayStatus) {
+    case 'active':
+      return 'active';
+    case 'past_due':
+      return 'past_due';
+    case 'canceled':
+      return 'canceled';
+    case 'incomplete':
+    case 'awaiting_first_charge':
+      return 'incomplete';
+    case 'intent':
+    case 'created':
+      return 'intent';
+    default:
+      return 'incomplete';
+  }
+}
+
+/**
+ * Project an OnvoPay subscription payload into a partial domain Subscription
+ * — just enough for the CreateSubscription use case to know the external id
+ * and status. The adapter does not own the full domain entity (id,
+ * customerReference, etc. are supplied by the use case layer).
+ */
+export function toSubscriptionProjection(
+  sub: OnvoPaySubscription,
+): Pick<Subscription, 'status' | 'gatewayRef'> {
+  return {
+    status: toSubscriptionStatus(sub.status),
+    gatewayRef: toGatewayRef(sub.id),
+  };
+}

--- a/src/adapters/outbound/gateways/onvopay/payment-gateway.ts
+++ b/src/adapters/outbound/gateways/onvopay/payment-gateway.ts
@@ -1,0 +1,170 @@
+// =============================================================================
+// OnvoPay PaymentGatewayPort implementation
+// -----------------------------------------------------------------------------
+// Implements `PaymentGatewayPort` against OnvoPay's charges API. Charge
+// creation, confirmation, capture, and refund all funnel through
+// `OnvoPayHttpClient` so retry/timeout policy is centralized.
+//
+// Endpoint assumptions (TODO: verify against
+// https://docs.onvopay.com/#section/Referencia-API):
+//   - POST   /v1/charges                  create charge
+//   - POST   /v1/charges/:id/confirm      complete 3DS / SCA
+//   - POST   /v1/charges/:id/capture      capture authorized funds
+//   - POST   /v1/refunds                  create refund against a charge
+//
+// If OnvoPay instead uses a separate PaymentIntent object or a different
+// path structure, update the four `this.http.request(...)` call sites below
+// — no other file needs to change because mappers + errors are centralized.
+// =============================================================================
+
+import type {
+  CapturePaymentInput,
+  CapturePaymentResult,
+  ConfirmPaymentInput,
+  ConfirmPaymentResult,
+  InitiatePaymentInput,
+  InitiatePaymentResult,
+  PaymentGatewayPort,
+  RefundPaymentInput,
+  RefundPaymentResult,
+} from '../../../../domain/ports/index.js';
+
+import { mapOnvoPayError } from './errors.js';
+import {
+  toConfirmStatus,
+  toGatewayRef,
+  toOnvoPayAmount,
+  type OnvoPayCharge,
+  type OnvoPayRefund,
+} from './mappers.js';
+import type { OnvoPayHttpClient } from './client.js';
+
+const CHARGES_PATH = '/v1/charges';
+const REFUNDS_PATH = '/v1/refunds';
+
+export class OnvoPayPaymentGateway implements PaymentGatewayPort {
+  readonly gateway = 'onvopay' as const;
+
+  constructor(private readonly http: OnvoPayHttpClient) {}
+
+  async initiate(input: InitiatePaymentInput): Promise<InitiatePaymentResult> {
+    try {
+      const body = {
+        amount: toOnvoPayAmount(input.amount),
+        currency: input.amount.currency,
+        customer: input.customerReference,
+        description: input.description,
+        return_url: input.returnUrl,
+        cancel_url: input.cancelUrl,
+        metadata: { ...input.metadata, consumer: input.consumer },
+      };
+      const charge = await this.http.request<OnvoPayCharge>({
+        method: 'POST',
+        path: CHARGES_PATH,
+        idempotencyKey: input.idempotencyKey,
+        body,
+      });
+
+      const requiresAction = charge.status === 'requires_action';
+      const redirectUrl =
+        charge.checkout_url ?? charge.next_action?.redirect_url ?? undefined;
+
+      const result: InitiatePaymentResult = {
+        gatewayRef: toGatewayRef(charge.id),
+        requiresAction,
+        ...(requiresAction && redirectUrl
+          ? {
+              // The domain treats the challenge payload as opaque bytes; we
+              // encode the redirect URL here so downstream consumers have
+              // enough signal to present the hosted 3DS page without the
+              // domain layer having to know about OnvoPay's shape.
+              challenge: {
+                challengeId: charge.id,
+                data: new TextEncoder().encode(redirectUrl),
+              },
+            }
+          : {}),
+        ...(charge.checkout_url ? { checkoutUrl: charge.checkout_url } : {}),
+      };
+      return result;
+    } catch (err) {
+      throw mapOnvoPayError(err);
+    }
+  }
+
+  async confirm(input: ConfirmPaymentInput): Promise<ConfirmPaymentResult> {
+    try {
+      // TODO: verify endpoint shape against https://docs.onvopay.com/ —
+      // OnvoPay may expose `/v1/charges/:id/confirm` or a unified
+      // `/v1/payment_intents/:id/confirm`.
+      const charge = await this.http.request<OnvoPayCharge>({
+        method: 'POST',
+        path: `${CHARGES_PATH}/${encodeURIComponent(input.gatewayRef.externalId)}/confirm`,
+        idempotencyKey: input.idempotencyKey,
+        body: {
+          three_ds_result: input.threeDsResult,
+          wallet_token:
+            input.walletTokenPayload === undefined
+              ? undefined
+              : Buffer.from(input.walletTokenPayload).toString('base64'),
+        },
+      });
+
+      const status = toConfirmStatus(charge.status);
+      const result: ConfirmPaymentResult = {
+        gatewayRef: toGatewayRef(charge.id),
+        status,
+        ...(charge.failure_reason ? { failureReason: charge.failure_reason } : {}),
+      };
+      return result;
+    } catch (err) {
+      throw mapOnvoPayError(err);
+    }
+  }
+
+  async capture(input: CapturePaymentInput): Promise<CapturePaymentResult> {
+    try {
+      const body: Record<string, unknown> = {};
+      if (input.amount !== undefined) {
+        body['amount'] = toOnvoPayAmount(input.amount);
+      }
+      const charge = await this.http.request<OnvoPayCharge>({
+        method: 'POST',
+        path: `${CHARGES_PATH}/${encodeURIComponent(input.gatewayRef.externalId)}/capture`,
+        idempotencyKey: input.idempotencyKey,
+        body,
+      });
+      const status = toConfirmStatus(charge.status) === 'succeeded' ? 'succeeded' : 'failed';
+      return { gatewayRef: toGatewayRef(charge.id), status };
+    } catch (err) {
+      throw mapOnvoPayError(err);
+    }
+  }
+
+  async refund(input: RefundPaymentInput): Promise<RefundPaymentResult> {
+    try {
+      const body: Record<string, unknown> = {
+        charge: input.gatewayRef.externalId,
+      };
+      if (input.amount !== undefined) {
+        body['amount'] = toOnvoPayAmount(input.amount);
+      }
+      if (input.reason !== undefined) {
+        body['reason'] = input.reason;
+      }
+      const refund = await this.http.request<OnvoPayRefund>({
+        method: 'POST',
+        path: REFUNDS_PATH,
+        idempotencyKey: input.idempotencyKey,
+        body,
+      });
+      const status = refund.status === 'succeeded' ? 'succeeded' : 'failed';
+      return {
+        refundGatewayRef: toGatewayRef(refund.id),
+        status,
+      };
+    } catch (err) {
+      throw mapOnvoPayError(err);
+    }
+  }
+}

--- a/src/adapters/outbound/gateways/onvopay/subscription.ts
+++ b/src/adapters/outbound/gateways/onvopay/subscription.ts
@@ -11,10 +11,10 @@
 //   - DELETE  /v1/subscriptions/:id                  cancel (immediate)
 //   - POST    /v1/subscriptions/:id/cancel           cancel-at-period-end flag
 //
-// `prorate` is a best-effort computation: OnvoPay may not expose a
-// dedicated proration preview endpoint. If not available, the method falls
-// back to returning the current + new plan amounts as the next-cycle figure
-// and documents the limitation in docs/content/docs/adapters/onvopay.md.
+// `prorate` is not implemented in this change: OnvoPay's proration preview
+// endpoint has not been verified against live docs and we refuse to return
+// fabricated numbers. The method throws ADAPTER_ONVOPAY_NOT_IMPLEMENTED;
+// see docs/content/docs/adapters/onvopay.md for the follow-up.
 // =============================================================================
 
 import type {
@@ -29,7 +29,6 @@ import type {
   SwitchSubscriptionResult,
 } from '../../../../domain/ports/index.js';
 import { DomainError } from '../../../../domain/errors.js';
-import { Money } from '../../../../domain/value_objects/money.js';
 
 import { mapOnvoPayError } from './errors.js';
 import {
@@ -142,10 +141,6 @@ export class OnvoPaySubscriptionGateway implements SubscriptionPort {
     // amounts via Money.of(BigInt(amount), currency), and return. Keep the
     // bigint / JSON-number boundary tight: the parse path is the only place
     // the adapter converts OnvoPay JSON numbers back into bigints.
-    //
-    // Referencing Money here keeps the domain import in the source graph so
-    // the future implementation can consume the type without additional imports.
-    void Money;
     throw new DomainError(
       'ADAPTER_ONVOPAY_NOT_IMPLEMENTED',
       'prorate is not implemented for OnvoPay; see onvopay-adapter-p0 follow-ups.',

--- a/src/adapters/outbound/gateways/onvopay/subscription.ts
+++ b/src/adapters/outbound/gateways/onvopay/subscription.ts
@@ -1,0 +1,154 @@
+// =============================================================================
+// OnvoPay SubscriptionPort implementation
+// -----------------------------------------------------------------------------
+// Implements `SubscriptionPort` against OnvoPay's recurring-charges API
+// (Cargos Recurrentes).
+//
+// Endpoint assumptions (TODO: verify against
+// https://docs.onvopay.com/#tag/Cargos-recurrentes):
+//   - POST    /v1/subscriptions                      create subscription
+//   - PATCH   /v1/subscriptions/:id                  switch plan / prorate
+//   - DELETE  /v1/subscriptions/:id                  cancel (immediate)
+//   - POST    /v1/subscriptions/:id/cancel           cancel-at-period-end flag
+//
+// `prorate` is a best-effort computation: OnvoPay may not expose a
+// dedicated proration preview endpoint. If not available, the method falls
+// back to returning the current + new plan amounts as the next-cycle figure
+// and documents the limitation in docs/content/docs/adapters/onvopay.md.
+// =============================================================================
+
+import type {
+  CancelSubscriptionInput,
+  CancelSubscriptionResult,
+  CreateSubscriptionPortInput,
+  CreateSubscriptionPortResult,
+  ProrateInput,
+  ProrateResult,
+  SubscriptionPort,
+  SwitchSubscriptionInput,
+  SwitchSubscriptionResult,
+} from '../../../../domain/ports/index.js';
+import { DomainError } from '../../../../domain/errors.js';
+import { Money } from '../../../../domain/value_objects/money.js';
+
+import { mapOnvoPayError } from './errors.js';
+import {
+  toGatewayRef,
+  toSubscriptionStatus,
+  type OnvoPaySubscription,
+} from './mappers.js';
+import type { OnvoPayHttpClient } from './client.js';
+
+const SUBSCRIPTIONS_PATH = '/v1/subscriptions';
+
+export class OnvoPaySubscriptionGateway implements SubscriptionPort {
+  readonly gateway = 'onvopay' as const;
+
+  constructor(private readonly http: OnvoPayHttpClient) {}
+
+  async create(input: CreateSubscriptionPortInput): Promise<CreateSubscriptionPortResult> {
+    try {
+      const body = {
+        customer: input.customerReference,
+        plan: input.planId,
+        metadata: { ...input.metadata, consumer: input.consumer },
+      };
+      const sub = await this.http.request<OnvoPaySubscription>({
+        method: 'POST',
+        path: SUBSCRIPTIONS_PATH,
+        idempotencyKey: input.idempotencyKey,
+        body,
+      });
+      return {
+        gatewayRef: toGatewayRef(sub.id),
+        status: toSubscriptionStatus(sub.status),
+      };
+    } catch (err) {
+      throw mapOnvoPayError(err);
+    }
+  }
+
+  async switch(input: SwitchSubscriptionInput): Promise<SwitchSubscriptionResult> {
+    try {
+      const body = {
+        plan: input.newPlanId,
+        // TODO: verify the proration-behavior enum accepted by
+        // https://docs.onvopay.com/#tag/Cargos-recurrentes. The Stripe vocabulary
+        // ('create_prorations', 'none', 'always_invoice') is passed through
+        // unchanged; OnvoPay may accept a different enum.
+        proration_behavior: input.prorationBehavior,
+      };
+      const sub = await this.http.request<OnvoPaySubscription>({
+        method: 'PATCH',
+        path: `${SUBSCRIPTIONS_PATH}/${encodeURIComponent(input.gatewayRef.externalId)}`,
+        idempotencyKey: input.idempotencyKey,
+        body,
+      });
+      return {
+        gatewayRef: toGatewayRef(sub.id),
+        status: toSubscriptionStatus(sub.status),
+      };
+    } catch (err) {
+      throw mapOnvoPayError(err);
+    }
+  }
+
+  async cancel(input: CancelSubscriptionInput): Promise<CancelSubscriptionResult> {
+    try {
+      // Immediate cancellation: DELETE /subscriptions/:id. Cancel-at-period-end
+      // is modeled as POST /subscriptions/:id/cancel with a body flag because
+      // DELETE bodies are inconsistently handled across HTTP clients.
+      const effectiveAt = new Date();
+      if (input.atPeriodEnd) {
+        const sub = await this.http.request<OnvoPaySubscription>({
+          method: 'POST',
+          path: `${SUBSCRIPTIONS_PATH}/${encodeURIComponent(input.gatewayRef.externalId)}/cancel`,
+          idempotencyKey: input.idempotencyKey,
+          body: { at_period_end: true, reason: input.reason },
+        });
+        return {
+          gatewayRef: toGatewayRef(sub.id),
+          status: toSubscriptionStatus(sub.status),
+          // TODO: verify whether OnvoPay returns the effective-at timestamp in
+          // the subscription payload (e.g. `cancel_at`). For now we stamp the
+          // adapter-side clock as a conservative lower bound.
+          effectiveAt,
+        };
+      }
+      const sub = await this.http.request<OnvoPaySubscription>({
+        method: 'DELETE',
+        path: `${SUBSCRIPTIONS_PATH}/${encodeURIComponent(input.gatewayRef.externalId)}`,
+        idempotencyKey: input.idempotencyKey,
+      });
+      return {
+        gatewayRef: toGatewayRef(sub.id),
+        status: toSubscriptionStatus(sub.status),
+        effectiveAt,
+      };
+    } catch (err) {
+      throw mapOnvoPayError(err);
+    }
+  }
+
+  async prorate(_input: ProrateInput): Promise<ProrateResult> {
+    // TODO: verify against https://docs.onvopay.com/#tag/Cargos-recurrentes —
+    // OnvoPay may expose `GET /subscriptions/:id/preview?plan=...` (or a
+    // similarly-named endpoint) that returns the prorated delta plus the
+    // next-cycle invoice amount. Until verified, this method throws rather
+    // than return a fabricated figure, so use-case-layer callers see an
+    // explicit capability gap instead of silent wrong numbers.
+    //
+    // When implementing: call the preview endpoint, parse the two Money
+    // amounts via Money.of(BigInt(amount), currency), and return. Keep the
+    // bigint / JSON-number boundary tight: the parse path is the only place
+    // the adapter converts OnvoPay JSON numbers back into bigints.
+    //
+    // Referencing Money here keeps the domain import in the source graph so
+    // the future implementation can consume the type without additional imports.
+    void Money;
+    throw new DomainError(
+      'ADAPTER_ONVOPAY_NOT_IMPLEMENTED',
+      'prorate is not implemented for OnvoPay; see onvopay-adapter-p0 follow-ups.',
+    );
+  }
+}

--- a/src/adapters/outbound/gateways/onvopay/webhook-verifier.ts
+++ b/src/adapters/outbound/gateways/onvopay/webhook-verifier.ts
@@ -61,6 +61,15 @@ export class WebhookDuplicateEventError extends DomainError {
  * Pluggable dedupe store. A production implementation persists seen event
  * ids for the gateway-documented retention window (OnvoPay's is not
  * published at time of writing — TODO: verify — use 24h as a baseline).
+ *
+ * The verifier marks an event as seen IMMEDIATELY after a successful
+ * signature check. That is intentionally aggressive — it prevents attackers
+ * from replaying a captured webhook to force side effects during the window
+ * where the application layer is still processing the first delivery. The
+ * application-layer `ProcessWebhook` use case also has its own idempotency
+ * check (on `eventId` AND on the request's `idempotencyKey`), so a
+ * legitimate gateway retry after a transient processing failure is absorbed
+ * at that layer rather than here.
  */
 export interface OnvoPayWebhookDedupeStore {
   /** Returns true if `eventId` has been marked seen previously. */

--- a/src/adapters/outbound/gateways/onvopay/webhook-verifier.ts
+++ b/src/adapters/outbound/gateways/onvopay/webhook-verifier.ts
@@ -1,0 +1,178 @@
+// =============================================================================
+// OnvoPay WebhookVerifierPort implementation
+// -----------------------------------------------------------------------------
+// Verifies OnvoPay-signed webhooks using HMAC-SHA256 over the raw request
+// body. Verification MUST run before any JSON parsing — the signature is
+// computed over the exact bytes the gateway signed, so even whitespace
+// differences break the hash.
+//
+// Signature scheme assumption (TODO: verify against
+// https://docs.onvopay.com/ webhook section):
+//   - Algorithm: HMAC-SHA256
+//   - Signing secret: `ONVOPAY_WEBHOOK_SIGNING_SECRET`
+//   - Header: a single hex digest (may include a `timestamp=` pair; the
+//     common industry shape is `t=<unix>,v1=<hex>`, matching Stripe's
+//     convention)
+//
+// If OnvoPay uses a JWT-based scheme instead (rare for webhooks), rewrite
+// this file to verify the JWT against the JWKS endpoint and extract the
+// event payload from the token body. Keep the port contract unchanged.
+//
+// Duplicate events (replay attacks or gateway retries after partial
+// acknowledgement) are rejected via the `seenEventIds` set supplied by the
+// caller. In production the set is a Redis/Postgres-backed dedupe store;
+// this module does not own the store.
+// =============================================================================
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+import { DomainError } from '../../../../domain/errors.js';
+import type {
+  VerifyWebhookInput,
+  WebhookEvent,
+  WebhookVerifierPort,
+} from '../../../../domain/ports/index.js';
+
+import type { OnvoPayWebhookEvent } from './mappers.js';
+
+export class WebhookSignatureError extends DomainError {
+  constructor(message: string) {
+    super('ADAPTER_ONVOPAY_WEBHOOK_SIGNATURE', message);
+    this.name = 'WebhookSignatureError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class WebhookDuplicateEventError extends DomainError {
+  public readonly eventId: string;
+
+  constructor(eventId: string) {
+    super(
+      'ADAPTER_ONVOPAY_WEBHOOK_DUPLICATE',
+      `OnvoPay webhook event '${eventId}' already processed.`,
+    );
+    this.name = 'WebhookDuplicateEventError';
+    this.eventId = eventId;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Pluggable dedupe store. A production implementation persists seen event
+ * ids for the gateway-documented retention window (OnvoPay's is not
+ * published at time of writing — TODO: verify — use 24h as a baseline).
+ */
+export interface OnvoPayWebhookDedupeStore {
+  /** Returns true if `eventId` has been marked seen previously. */
+  has(eventId: string): Promise<boolean>;
+  /** Marks `eventId` as seen. Idempotent. */
+  mark(eventId: string): Promise<void>;
+}
+
+export interface OnvoPayWebhookVerifierConfig {
+  /** Shared secret provisioned by OnvoPay's merchant dashboard. */
+  readonly signingSecret: string;
+  /** Dedupe store for eventId-based replay protection. */
+  readonly dedupe: OnvoPayWebhookDedupeStore;
+}
+
+/**
+ * In-memory dedupe store suitable for tests. Not safe for multi-process
+ * deployments — use a shared Redis/Postgres store in production.
+ */
+export class InMemoryOnvoPayDedupeStore implements OnvoPayWebhookDedupeStore {
+  private readonly seen = new Set<string>();
+
+  async has(eventId: string): Promise<boolean> {
+    return this.seen.has(eventId);
+  }
+
+  async mark(eventId: string): Promise<void> {
+    this.seen.add(eventId);
+  }
+}
+
+export class OnvoPayWebhookVerifier implements WebhookVerifierPort {
+  readonly gateway = 'onvopay' as const;
+
+  constructor(private readonly config: OnvoPayWebhookVerifierConfig) {}
+
+  async verify(input: VerifyWebhookInput): Promise<WebhookEvent> {
+    this.assertSignatureValid(input.signature, input.payload);
+
+    // Signature OK — now safe to parse.
+    let parsed: OnvoPayWebhookEvent;
+    try {
+      const text = new TextDecoder().decode(input.payload);
+      parsed = JSON.parse(text) as OnvoPayWebhookEvent;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new WebhookSignatureError(
+        `OnvoPay webhook payload is not valid JSON after signature passed: ${message}`,
+      );
+    }
+    if (!parsed.id || !parsed.type) {
+      throw new WebhookSignatureError(
+        'OnvoPay webhook payload missing required `id` or `type` fields.',
+      );
+    }
+    if (await this.config.dedupe.has(parsed.id)) {
+      throw new WebhookDuplicateEventError(parsed.id);
+    }
+    await this.config.dedupe.mark(parsed.id);
+
+    return {
+      gateway: 'onvopay',
+      eventId: parsed.id,
+      eventType: parsed.type,
+      payload: input.payload,
+      occurredAt: parsed.created_at ? new Date(parsed.created_at) : input.receivedAt,
+    };
+  }
+
+  private assertSignatureValid(signatureHeader: string, payload: Uint8Array): void {
+    if (!signatureHeader) {
+      throw new WebhookSignatureError('OnvoPay signature header is missing.');
+    }
+    const provided = extractHexSignature(signatureHeader);
+    const expectedHex = createHmac('sha256', this.config.signingSecret)
+      .update(payload)
+      .digest('hex');
+
+    const providedBuf = safeFromHex(provided);
+    const expectedBuf = Buffer.from(expectedHex, 'hex');
+    if (providedBuf === null || providedBuf.length !== expectedBuf.length) {
+      throw new WebhookSignatureError('OnvoPay signature has wrong length or encoding.');
+    }
+    if (!timingSafeEqual(providedBuf, expectedBuf)) {
+      throw new WebhookSignatureError('OnvoPay signature does not match.');
+    }
+  }
+}
+
+/**
+ * Extract the hex signature from the raw header. Accepts both the bare-hex
+ * form (`abc123...`) and the `t=<unix>,v1=<hex>` composite form, mirroring
+ * the most common webhook-signature conventions.
+ *
+ * TODO: verify header shape against https://docs.onvopay.com/ webhook
+ * section. If OnvoPay uses `v0` or a dedicated `onvopay-signature` /
+ * `x-onvopay-signature` scheme with a fixed layout, simplify the parser.
+ */
+function extractHexSignature(header: string): string {
+  const segments = header.split(',').map((s) => s.trim());
+  for (const seg of segments) {
+    if (seg.startsWith('v1=')) {
+      return seg.slice(3);
+    }
+  }
+  // No `v1=` segment — assume the whole header is the hex digest.
+  return header.trim();
+}
+
+function safeFromHex(hex: string): Buffer | null {
+  if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length % 2 !== 0) {
+    return null;
+  }
+  return Buffer.from(hex, 'hex');
+}

--- a/test/adapters/outbound/gateways/onvopay/payment-gateway.test.ts
+++ b/test/adapters/outbound/gateways/onvopay/payment-gateway.test.ts
@@ -1,0 +1,313 @@
+// =============================================================================
+// OnvoPayPaymentGateway unit tests
+// -----------------------------------------------------------------------------
+// Exercises the PaymentGatewayPort implementation against a hand-rolled
+// `node:http` stub. No external mocking library — msw@2 would work but adding
+// it is not worth the dependency budget for three test files.
+//
+// Each test spins up an ephemeral port, asserts the outgoing request looks
+// correct, and returns a canned OnvoPay-shaped response.
+// =============================================================================
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import { Money } from '../../../../../src/domain/value_objects/money.js';
+import { idempotencyKey } from '../../../../../src/domain/value_objects/idempotency-key.js';
+import { InvalidMoneyError } from '../../../../../src/domain/errors.js';
+
+import {
+  OnvoPayPaymentGateway,
+  OnvoPayCardDeclinedError,
+  OnvoPayAuthError,
+  OnvoPayInvalidRequestError,
+  createOnvoPayHttpClient,
+} from '../../../../../src/adapters/outbound/gateways/onvopay/index.js';
+
+// ---------------------------------------------------------------------------
+// HTTP stub
+// ---------------------------------------------------------------------------
+
+type Handler = (req: IncomingMessage, res: ServerResponse, body: string) => void;
+
+interface Recorded {
+  method: string;
+  path: string;
+  headers: Record<string, string | string[] | undefined>;
+  body: string;
+}
+
+async function startStub(handler: Handler): Promise<{
+  baseUrl: string;
+  close: () => Promise<void>;
+  recorded: Recorded[];
+  server: Server;
+}> {
+  const recorded: Recorded[] = [];
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf8');
+      recorded.push({
+        method: req.method ?? '',
+        path: req.url ?? '',
+        headers: req.headers as Record<string, string | string[] | undefined>,
+        body,
+      });
+      handler(req, res, body);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${addr.port}`;
+  const close = () =>
+    new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  return { baseUrl, close, recorded, server };
+}
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OnvoPayPaymentGateway', () => {
+  const servers: Array<{ close: () => Promise<void> }> = [];
+  afterEach(async () => {
+    while (servers.length) {
+      const s = servers.pop();
+      if (s) {
+        await s.close();
+      }
+    }
+  });
+
+  it('initiate: sends a POST /v1/charges with bearer auth + idempotency key and maps the response', async () => {
+    const stub = await startStub((req, res, _body) => {
+      json(res, 200, {
+        id: 'chr_123',
+        amount: 1500,
+        currency: 'CRC',
+        status: 'succeeded',
+      });
+    });
+    servers.push(stub);
+
+    const http = createOnvoPayHttpClient({
+      apiBaseUrl: stub.baseUrl,
+      apiKey: 'sk_test_abc',
+      maxRetries: 0,
+    });
+    const gateway = new OnvoPayPaymentGateway(http);
+
+    const result = await gateway.initiate({
+      amount: Money.of(1500n, 'CRC'),
+      consumer: 'habitanexus-api',
+      customerReference: 'cust_1',
+      idempotencyKey: idempotencyKey('test-ch-00000001'),
+      metadata: { invoice: 'INV-9' },
+    });
+
+    expect(result.gatewayRef).toEqual({ gateway: 'onvopay', externalId: 'chr_123' });
+    expect(result.requiresAction).toBe(false);
+
+    const rec = stub.recorded[0];
+    expect(rec).toBeDefined();
+    expect(rec?.method).toBe('POST');
+    expect(rec?.path).toBe('/v1/charges');
+    expect(rec?.headers['authorization']).toBe('Bearer sk_test_abc');
+    expect(rec?.headers['idempotency-key']).toBe('test-ch-00000001');
+    const parsed = JSON.parse(rec?.body ?? '{}');
+    expect(parsed.amount).toBe(1500);
+    expect(parsed.currency).toBe('CRC');
+    expect(parsed.metadata.consumer).toBe('habitanexus-api');
+  });
+
+  it('initiate: surfaces `requires_action` + redirect URL from next_action', async () => {
+    const stub = await startStub((req, res) => {
+      json(res, 200, {
+        id: 'chr_456',
+        amount: 500,
+        currency: 'CRC',
+        status: 'requires_action',
+        next_action: { redirect_url: 'https://3ds.onvopay.com/xyz' },
+      });
+    });
+    servers.push(stub);
+
+    const http = createOnvoPayHttpClient({
+      apiBaseUrl: stub.baseUrl,
+      apiKey: 'sk_test_abc',
+      maxRetries: 0,
+    });
+    const gateway = new OnvoPayPaymentGateway(http);
+
+    const result = await gateway.initiate({
+      amount: Money.of(500n, 'CRC'),
+      consumer: 'habitanexus-api',
+      customerReference: 'cust_1',
+      idempotencyKey: idempotencyKey('test-ch-00000002'),
+      metadata: {},
+    });
+    expect(result.requiresAction).toBe(true);
+    expect(result.challenge).toBeDefined();
+    expect(new TextDecoder().decode(result.challenge?.data)).toBe(
+      'https://3ds.onvopay.com/xyz',
+    );
+  });
+
+  it('initiate: rejects non-CRC currencies with InvalidMoneyError (CRC-only policy)', async () => {
+    const stub = await startStub((_req, res) => json(res, 200, {}));
+    servers.push(stub);
+    const http = createOnvoPayHttpClient({
+      apiBaseUrl: stub.baseUrl,
+      apiKey: 'sk_test_abc',
+      maxRetries: 0,
+    });
+    const gateway = new OnvoPayPaymentGateway(http);
+
+    await expect(
+      gateway.initiate({
+        amount: Money.of(1000n, 'USD'),
+        consumer: 'habitanexus-api',
+        customerReference: 'cust_1',
+        idempotencyKey: idempotencyKey('test-ch-00000003'),
+        metadata: {},
+      }),
+    ).rejects.toBeInstanceOf(InvalidMoneyError);
+    // No outgoing request should have been made.
+    expect(stub.recorded).toHaveLength(0);
+  });
+
+  it('initiate: maps HTTP 402 to OnvoPayCardDeclinedError', async () => {
+    const stub = await startStub((_req, res) => {
+      json(res, 402, { error: 'card_declined' });
+    });
+    servers.push(stub);
+
+    const http = createOnvoPayHttpClient({
+      apiBaseUrl: stub.baseUrl,
+      apiKey: 'sk_test_abc',
+      maxRetries: 0,
+    });
+    const gateway = new OnvoPayPaymentGateway(http);
+
+    await expect(
+      gateway.initiate({
+        amount: Money.of(1000n, 'CRC'),
+        consumer: 'habitanexus-api',
+        customerReference: 'cust_1',
+        idempotencyKey: idempotencyKey('test-ch-00000004'),
+        metadata: {},
+      }),
+    ).rejects.toBeInstanceOf(OnvoPayCardDeclinedError);
+  });
+
+  it('initiate: maps HTTP 401 to OnvoPayAuthError and never retries', async () => {
+    let hits = 0;
+    const stub = await startStub((_req, res) => {
+      hits++;
+      json(res, 401, { error: 'unauthorized' });
+    });
+    servers.push(stub);
+
+    const http = createOnvoPayHttpClient({
+      apiBaseUrl: stub.baseUrl,
+      apiKey: 'sk_test_abc',
+      maxRetries: 3, // If business errors were retried, we'd see >1 hit.
+    });
+    const gateway = new OnvoPayPaymentGateway(http);
+
+    await expect(
+      gateway.initiate({
+        amount: Money.of(1n, 'CRC'),
+        consumer: 'habitanexus-api',
+        customerReference: 'cust_1',
+        idempotencyKey: idempotencyKey('test-ch-00000005'),
+        metadata: {},
+      }),
+    ).rejects.toBeInstanceOf(OnvoPayAuthError);
+    expect(hits).toBe(1);
+  });
+
+  it('initiate: maps HTTP 422 to OnvoPayInvalidRequestError', async () => {
+    const stub = await startStub((_req, res) => json(res, 422, { error: 'bad' }));
+    servers.push(stub);
+
+    const http = createOnvoPayHttpClient({
+      apiBaseUrl: stub.baseUrl,
+      apiKey: 'sk_test_abc',
+      maxRetries: 0,
+    });
+    const gateway = new OnvoPayPaymentGateway(http);
+
+    await expect(
+      gateway.initiate({
+        amount: Money.of(1n, 'CRC'),
+        consumer: 'habitanexus-api',
+        customerReference: 'cust_1',
+        idempotencyKey: idempotencyKey('test-ch-00000006'),
+        metadata: {},
+      }),
+    ).rejects.toBeInstanceOf(OnvoPayInvalidRequestError);
+  });
+
+  it('refund: POSTs to /v1/refunds with the charge id', async () => {
+    const stub = await startStub((_req, res) => {
+      json(res, 200, { id: 'ref_1', status: 'succeeded' });
+    });
+    servers.push(stub);
+
+    const http = createOnvoPayHttpClient({
+      apiBaseUrl: stub.baseUrl,
+      apiKey: 'sk_test_abc',
+      maxRetries: 0,
+    });
+    const gateway = new OnvoPayPaymentGateway(http);
+
+    const result = await gateway.refund({
+      gatewayRef: { gateway: 'onvopay', externalId: 'chr_123' },
+      idempotencyKey: idempotencyKey('test-rf-00000001'),
+      amount: Money.of(500n, 'CRC'),
+      reason: 'customer_request',
+    });
+    expect(result.refundGatewayRef.externalId).toBe('ref_1');
+    expect(result.status).toBe('succeeded');
+
+    const rec = stub.recorded[0];
+    expect(rec?.path).toBe('/v1/refunds');
+    const body = JSON.parse(rec?.body ?? '{}');
+    expect(body.charge).toBe('chr_123');
+    expect(body.amount).toBe(500);
+    expect(body.reason).toBe('customer_request');
+  });
+
+  it('capture: POSTs to /v1/charges/:id/capture', async () => {
+    const stub = await startStub((_req, res) => {
+      json(res, 200, { id: 'chr_xyz', status: 'succeeded', amount: 1000, currency: 'CRC' });
+    });
+    servers.push(stub);
+
+    const http = createOnvoPayHttpClient({
+      apiBaseUrl: stub.baseUrl,
+      apiKey: 'sk_test_abc',
+      maxRetries: 0,
+    });
+    const gateway = new OnvoPayPaymentGateway(http);
+
+    const result = await gateway.capture({
+      gatewayRef: { gateway: 'onvopay', externalId: 'chr_xyz' },
+      idempotencyKey: idempotencyKey('test-cp-00000001'),
+    });
+    expect(result.status).toBe('succeeded');
+    expect(stub.recorded[0]?.path).toBe('/v1/charges/chr_xyz/capture');
+  });
+});

--- a/test/adapters/outbound/gateways/onvopay/subscription.test.ts
+++ b/test/adapters/outbound/gateways/onvopay/subscription.test.ts
@@ -1,0 +1,205 @@
+// =============================================================================
+// OnvoPaySubscriptionGateway unit tests
+// -----------------------------------------------------------------------------
+// Same HTTP-stub pattern as the payment-gateway tests, focused on the
+// SubscriptionPort surface (create, switch, cancel, prorate).
+// =============================================================================
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import { idempotencyKey } from '../../../../../src/domain/value_objects/idempotency-key.js';
+
+import {
+  OnvoPaySubscriptionGateway,
+  createOnvoPayHttpClient,
+} from '../../../../../src/adapters/outbound/gateways/onvopay/index.js';
+
+interface Recorded {
+  method: string;
+  path: string;
+  body: string;
+  idempotencyKey: string | undefined;
+}
+
+async function startStub(
+  handler: (req: IncomingMessage, res: ServerResponse, body: string) => void,
+): Promise<{
+  baseUrl: string;
+  close: () => Promise<void>;
+  recorded: Recorded[];
+}> {
+  const recorded: Recorded[] = [];
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf8');
+      const idem = req.headers['idempotency-key'];
+      recorded.push({
+        method: req.method ?? '',
+        path: req.url ?? '',
+        body,
+        idempotencyKey: typeof idem === 'string' ? idem : undefined,
+      });
+      handler(req, res, body);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${addr.port}`;
+  const close = () =>
+    new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  return { baseUrl, close, recorded };
+}
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+describe('OnvoPaySubscriptionGateway', () => {
+  const stubs: Array<{ close: () => Promise<void> }> = [];
+  afterEach(async () => {
+    while (stubs.length) {
+      const s = stubs.pop();
+      if (s) {
+        await s.close();
+      }
+    }
+  });
+
+  it('create: POSTs /v1/subscriptions and maps status', async () => {
+    const stub = await startStub((_req, res) =>
+      json(res, 200, { id: 'sub_123', status: 'active', plan_id: 'plan_monthly' }),
+    );
+    stubs.push(stub);
+
+    const http = createOnvoPayHttpClient({
+      apiBaseUrl: stub.baseUrl,
+      apiKey: 'sk_test',
+      maxRetries: 0,
+    });
+    const gateway = new OnvoPaySubscriptionGateway(http);
+
+    const r = await gateway.create({
+      consumer: 'habitanexus-api',
+      customerReference: 'cust_1',
+      planId: 'plan_monthly',
+      idempotencyKey: idempotencyKey('test-sub-00000001'),
+      metadata: { hoa_id: 'HOA-42' },
+    });
+
+    expect(r.gatewayRef.externalId).toBe('sub_123');
+    expect(r.status).toBe('active');
+    expect(stubs[0]).toBeDefined();
+    expect(stub.recorded[0]?.method).toBe('POST');
+    expect(stub.recorded[0]?.path).toBe('/v1/subscriptions');
+    expect(stub.recorded[0]?.idempotencyKey).toBe('test-sub-00000001');
+    const body = JSON.parse(stub.recorded[0]?.body ?? '{}');
+    expect(body.plan).toBe('plan_monthly');
+    expect(body.metadata.consumer).toBe('habitanexus-api');
+  });
+
+  it('switch: PATCHes /v1/subscriptions/:id with the new plan + proration behavior', async () => {
+    const stub = await startStub((_req, res) =>
+      json(res, 200, { id: 'sub_123', status: 'active' }),
+    );
+    stubs.push(stub);
+
+    const http = createOnvoPayHttpClient({
+      apiBaseUrl: stub.baseUrl,
+      apiKey: 'sk_test',
+      maxRetries: 0,
+    });
+    const gateway = new OnvoPaySubscriptionGateway(http);
+
+    await gateway.switch({
+      gatewayRef: { gateway: 'onvopay', externalId: 'sub_123' },
+      newPlanId: 'plan_yearly',
+      prorationBehavior: 'create_prorations',
+      idempotencyKey: idempotencyKey('test-sub-00000002'),
+    });
+
+    expect(stub.recorded[0]?.method).toBe('PATCH');
+    expect(stub.recorded[0]?.path).toBe('/v1/subscriptions/sub_123');
+    const body = JSON.parse(stub.recorded[0]?.body ?? '{}');
+    expect(body.plan).toBe('plan_yearly');
+    expect(body.proration_behavior).toBe('create_prorations');
+  });
+
+  it('cancel (immediate): DELETEs /v1/subscriptions/:id', async () => {
+    const stub = await startStub((_req, res) =>
+      json(res, 200, { id: 'sub_123', status: 'canceled' }),
+    );
+    stubs.push(stub);
+
+    const http = createOnvoPayHttpClient({
+      apiBaseUrl: stub.baseUrl,
+      apiKey: 'sk_test',
+      maxRetries: 0,
+    });
+    const gateway = new OnvoPaySubscriptionGateway(http);
+
+    const r = await gateway.cancel({
+      gatewayRef: { gateway: 'onvopay', externalId: 'sub_123' },
+      atPeriodEnd: false,
+      idempotencyKey: idempotencyKey('test-sub-00000003'),
+    });
+
+    expect(r.status).toBe('canceled');
+    expect(stub.recorded[0]?.method).toBe('DELETE');
+    expect(stub.recorded[0]?.path).toBe('/v1/subscriptions/sub_123');
+  });
+
+  it('cancel (at period end): POSTs /v1/subscriptions/:id/cancel with the flag', async () => {
+    const stub = await startStub((_req, res) =>
+      json(res, 200, { id: 'sub_123', status: 'active' }),
+    );
+    stubs.push(stub);
+
+    const http = createOnvoPayHttpClient({
+      apiBaseUrl: stub.baseUrl,
+      apiKey: 'sk_test',
+      maxRetries: 0,
+    });
+    const gateway = new OnvoPaySubscriptionGateway(http);
+
+    await gateway.cancel({
+      gatewayRef: { gateway: 'onvopay', externalId: 'sub_123' },
+      atPeriodEnd: true,
+      reason: 'user_requested',
+      idempotencyKey: idempotencyKey('test-sub-00000004'),
+    });
+
+    expect(stub.recorded[0]?.method).toBe('POST');
+    expect(stub.recorded[0]?.path).toBe('/v1/subscriptions/sub_123/cancel');
+    const body = JSON.parse(stub.recorded[0]?.body ?? '{}');
+    expect(body.at_period_end).toBe(true);
+    expect(body.reason).toBe('user_requested');
+  });
+
+  it('prorate: throws ADAPTER_ONVOPAY_NOT_IMPLEMENTED until the preview endpoint is verified', async () => {
+    const stub = await startStub((_req, res) => json(res, 500, {}));
+    stubs.push(stub);
+
+    const http = createOnvoPayHttpClient({
+      apiBaseUrl: stub.baseUrl,
+      apiKey: 'sk_test',
+      maxRetries: 0,
+    });
+    const gateway = new OnvoPaySubscriptionGateway(http);
+
+    await expect(
+      gateway.prorate({
+        gatewayRef: { gateway: 'onvopay', externalId: 'sub_123' },
+        newPlanId: 'plan_yearly',
+        idempotencyKey: idempotencyKey('test-sub-00000005'),
+      }),
+    ).rejects.toMatchObject({ code: 'ADAPTER_ONVOPAY_NOT_IMPLEMENTED' });
+  });
+});

--- a/test/adapters/outbound/gateways/onvopay/webhook-verifier.test.ts
+++ b/test/adapters/outbound/gateways/onvopay/webhook-verifier.test.ts
@@ -1,0 +1,176 @@
+// =============================================================================
+// OnvoPayWebhookVerifier unit tests
+// -----------------------------------------------------------------------------
+// Cover the three contract points the port promises:
+//
+//   1. A correctly-signed webhook produces a WebhookEvent with the gateway
+//      metadata populated.
+//   2. Any signature mismatch (bad secret, bad hex, truncated digest,
+//      missing header) throws WebhookSignatureError BEFORE any JSON parse.
+//   3. Duplicate event ids (replayed webhooks, gateway retries after a
+//      processing error ACK) are rejected on the second delivery.
+// =============================================================================
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createHmac } from 'node:crypto';
+
+import { idempotencyKey } from '../../../../../src/domain/value_objects/idempotency-key.js';
+
+import {
+  OnvoPayWebhookVerifier,
+  InMemoryOnvoPayDedupeStore,
+  WebhookDuplicateEventError,
+  WebhookSignatureError,
+} from '../../../../../src/adapters/outbound/gateways/onvopay/index.js';
+
+const SECRET = 'whsec_test_0123456789';
+
+function sign(payload: Uint8Array): string {
+  return createHmac('sha256', SECRET).update(payload).digest('hex');
+}
+
+function encode(obj: unknown): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(obj));
+}
+
+describe('OnvoPayWebhookVerifier', () => {
+  let verifier: OnvoPayWebhookVerifier;
+  let dedupe: InMemoryOnvoPayDedupeStore;
+
+  beforeEach(() => {
+    dedupe = new InMemoryOnvoPayDedupeStore();
+    verifier = new OnvoPayWebhookVerifier({ signingSecret: SECRET, dedupe });
+  });
+
+  it('accepts a valid HMAC-SHA256 signature (bare hex form)', async () => {
+    const payload = encode({
+      id: 'evt_1',
+      type: 'charge.succeeded',
+      created_at: '2026-04-18T00:00:00Z',
+    });
+    const event = await verifier.verify({
+      signature: sign(payload),
+      payload,
+      receivedAt: new Date('2026-04-18T00:00:01Z'),
+      idempotencyKey: idempotencyKey('test-wh-00000001'),
+    });
+    expect(event.gateway).toBe('onvopay');
+    expect(event.eventId).toBe('evt_1');
+    expect(event.eventType).toBe('charge.succeeded');
+    expect(event.payload).toBe(payload);
+    expect(event.occurredAt.toISOString()).toBe('2026-04-18T00:00:00.000Z');
+  });
+
+  it('accepts the composite `t=<unix>,v1=<hex>` header form', async () => {
+    const payload = encode({ id: 'evt_2', type: 'charge.refunded' });
+    const sig = sign(payload);
+    const composite = `t=1713396000,v1=${sig}`;
+    const event = await verifier.verify({
+      signature: composite,
+      payload,
+      receivedAt: new Date(),
+      idempotencyKey: idempotencyKey('test-wh-00000002'),
+    });
+    expect(event.eventId).toBe('evt_2');
+  });
+
+  it('rejects a tampered payload with WebhookSignatureError', async () => {
+    const original = encode({ id: 'evt_3', type: 'charge.succeeded' });
+    const sig = sign(original);
+    const tampered = encode({ id: 'evt_3', type: 'charge.refunded' });
+    await expect(
+      verifier.verify({
+        signature: sig,
+        payload: tampered,
+        receivedAt: new Date(),
+        idempotencyKey: idempotencyKey('test-wh-00000003'),
+      }),
+    ).rejects.toBeInstanceOf(WebhookSignatureError);
+  });
+
+  it('rejects a missing signature header', async () => {
+    const payload = encode({ id: 'evt_4', type: 'charge.succeeded' });
+    await expect(
+      verifier.verify({
+        signature: '',
+        payload,
+        receivedAt: new Date(),
+        idempotencyKey: idempotencyKey('test-wh-00000004'),
+      }),
+    ).rejects.toBeInstanceOf(WebhookSignatureError);
+  });
+
+  it('rejects a malformed hex signature (odd length) without attempting comparison', async () => {
+    const payload = encode({ id: 'evt_5', type: 'charge.succeeded' });
+    await expect(
+      verifier.verify({
+        signature: 'abc',
+        payload,
+        receivedAt: new Date(),
+        idempotencyKey: idempotencyKey('test-wh-00000005'),
+      }),
+    ).rejects.toBeInstanceOf(WebhookSignatureError);
+  });
+
+  it('rejects a wrong-secret signature of the right length', async () => {
+    const payload = encode({ id: 'evt_6', type: 'charge.succeeded' });
+    const wrongSig = createHmac('sha256', 'whsec_wrong').update(payload).digest('hex');
+    await expect(
+      verifier.verify({
+        signature: wrongSig,
+        payload,
+        receivedAt: new Date(),
+        idempotencyKey: idempotencyKey('test-wh-00000006'),
+      }),
+    ).rejects.toBeInstanceOf(WebhookSignatureError);
+  });
+
+  it('rejects duplicate event ids on a second delivery', async () => {
+    const payload = encode({ id: 'evt_dup', type: 'charge.succeeded' });
+    const sig = sign(payload);
+
+    // First delivery passes.
+    await verifier.verify({
+      signature: sig,
+      payload,
+      receivedAt: new Date(),
+      idempotencyKey: idempotencyKey('test-wh-00000007'),
+    });
+
+    // Second delivery (gateway retry / replay) rejected.
+    await expect(
+      verifier.verify({
+        signature: sig,
+        payload,
+        receivedAt: new Date(),
+        idempotencyKey: idempotencyKey('test-wh-00000008'),
+      }),
+    ).rejects.toBeInstanceOf(WebhookDuplicateEventError);
+  });
+
+  it('rejects a payload whose signature is valid but missing required fields', async () => {
+    const payload = encode({ id: '', type: '' });
+    const sig = sign(payload);
+    await expect(
+      verifier.verify({
+        signature: sig,
+        payload,
+        receivedAt: new Date(),
+        idempotencyKey: idempotencyKey('test-wh-00000009'),
+      }),
+    ).rejects.toBeInstanceOf(WebhookSignatureError);
+  });
+
+  it('falls back to receivedAt when OnvoPay does not provide created_at', async () => {
+    const payload = encode({ id: 'evt_no_ts', type: 'charge.succeeded' });
+    const sig = sign(payload);
+    const receivedAt = new Date('2026-05-01T12:00:00Z');
+    const event = await verifier.verify({
+      signature: sig,
+      payload,
+      receivedAt,
+      idempotencyKey: idempotencyKey('test-wh-0000000a'),
+    });
+    expect(event.occurredAt.toISOString()).toBe('2026-05-01T12:00:00.000Z');
+  });
+});


### PR DESCRIPTION
Closes #21.

## Summary

Second real gateway adapter (after Stripe, concurrent with #20) under `src/adapters/outbound/gateways/onvopay/`. HabitaNexus is the primary consumer; CR-native card acquiring, recurring charges, webhook verification.

## Ports implemented

- `PaymentGatewayPort` — initiate / confirm / capture / refund against `/v1/charges` + `/v1/refunds`.
- `SubscriptionPort` — create / switch / cancel against `/v1/subscriptions`. `prorate()` throws `ADAPTER_ONVOPAY_NOT_IMPLEMENTED` until a preview endpoint is verified.
- `WebhookVerifierPort` — HMAC-SHA256 over raw body; accepts both bare-hex and `t=<unix>,v1=<hex>` header shapes; rejects invalid signatures AND duplicate event ids via a pluggable dedupe store.

## Files (14, under the 15 budget)

- `src/adapters/outbound/gateways/onvopay/{client,errors,mappers,payment-gateway,subscription,webhook-verifier,index}.ts`
- `test/adapters/outbound/gateways/onvopay/{payment-gateway,subscription,webhook-verifier}.test.ts`
- `docs/content/docs/adapters/onvopay.md` (+ `docs/mkdocs.yml` nav entry)
- `.env.example` (OnvoPay env vars)
- `eslint.config.js` (isolation guard on `src/adapters/outbound/gateways/onvopay/**`)

## Hard constraints respected

- HTTP client only in `client.ts`. Every other file imports the `OnvoPayHttpClient` from there.
- `AbortSignal.timeout(10_000)` on every request.
- Retries ONLY on transient network errors. 4xx and 5xx surface as domain errors (never retried).
- No `axios`, no `node-fetch`, no new runtime deps. Native `fetch` only.
- No debug logs, no top-level side effects.
- ESLint rule forbids cross-adapter imports on the OnvoPay tree; allowed: `src/domain/**`, Node built-ins, `msw` (test-only, not actually used — we hand-rolled a `node:http` stub).
- CRC-only policy enforced at the gateway boundary via `assertOnvoPaySupportedCurrency()`; non-CRC `Money` throws `InvalidMoneyError` before any network call.

## `// TODO: verify` markers (22 total, see `docs/content/docs/adapters/onvopay.md` Verification Log)

`docs.onvopay.com` is a JS-heavy SPA that did not render markdown-friendly content via plain HTTP fetches during implementation. Every speculated endpoint shape, field name, header name, status enum, and error mapping is marked with `// TODO: verify against https://docs.onvopay.com/...`. Follow-up work: exercise against a real sandbox and close each TODO.

Key open TODOs:

- Auth scheme (`Authorization: Bearer` assumed — may be `x-api-key` or `Basic`).
- Idempotency header name (`Idempotency-Key` assumed).
- Multi-currency support (CRC-only today; USD may be possible for some merchants).
- CRC minor-unit convention (pass-through today).
- Complete charge + subscription status enums.
- Webhook signature header shape and algorithm.
- HTTP 402 vs 400-with-code for card declines.
- `/v1/charges/:id/confirm` path shape.
- `prorate` preview endpoint path and response shape.

## Verification (local)

```
pnpm lint        # clean
pnpm build       # tsc passes
pnpm test        # 147 passed (22 new)
mkdocs build --strict   # clean
```

## Known parallel work

- #19 (grpc-server-inbound) and #20 (stripe-adapter-p0) run simultaneously. Disjoint scopes. `eslint.config.js` and `docs/mkdocs.yml` may collide; will rebase if either lands first.

Created by Claude Code on behalf of @lapc506.