### PR TITLE
Cleanup: GatewayRegistry wire + domain bug + coverage-v8

### DIFF
--- a/openspec/changes/grpc-server-inbound/tasks.md
+++ b/openspec/changes/grpc-server-inbound/tasks.md
@@ -104,3 +104,12 @@
 - [ ] The generated Docker image is available at `ghcr.io/lapc506/payments-core:<first-tag>` after the first version tag is pushed.
 - [ ] Consumer repos can now wire a sidecar using `k8s/sidecar.example.yaml` as a reference.
 - [ ] `stripe-adapter-p0` and `onvopay-adapter-p0` drop their temporary `FakePaymentGateway` registrations from `main.ts` as they land.
+
+## Post-merge cleanup (landed in PR #41)
+
+Post-ola-final housekeeping bundled into a single micro-PR after the Stripe + OnvoPay adapters landed:
+
+- [x] Orphan local branch `docs/expand-openspec-change-stubs` (merged via PR #3) deleted from the maintainer's worktree. Remote state was already clean.
+- [x] Fixed `createEscrow` in `src/domain/entities/escrow.ts`: `releasedAmount` is now built via `Money.of(...)` so the returned entity carries a real `Money` instance with its prototype intact. The workaround in `ReleaseEscrow` that rebuilt the `Money` before calling `.add()` was removed.
+- [x] Added `@vitest/coverage-v8` as a devDependency (matches pinned `vitest@^1.6.0`). `vitest.config.ts` now declares the `v8` provider and emits `text-summary` + `lcov`, so `pnpm test -- --coverage` produces `coverage/lcov.info` consumable by CI reporters. Coverage thresholds are intentionally NOT enforced yet — that is a separate follow-up.
+- [x] `src/main.ts` replaced the `stub port: real adapter pending` wires for `PaymentGatewayPort`, `SubscriptionPort`, and `WebhookVerifierPort` with a `GatewayRegistry` (new helper in `src/main/gateway-registry.ts`). The registry constructs Stripe and OnvoPay adapters from env-supplied secrets; when a gateway has no credentials configured, requests for it return `GatewayUnavailableError(<gateway>, 'not configured')`, which the inbound translator maps to gRPC `UNAVAILABLE`. `EscrowPort`, `PayoutPort`, `AgenticPaymentPort`, `ReconciliationPort`, and `FXRatePort` keep their stub fallbacks — they do not have real adapters yet.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/node": "^20.11.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
+    "@vitest/coverage-v8": "^1.6.0",
     "eslint": "^9.0.0",
     "google-protobuf": "^3.21.4",
     "prettier": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^7.0.0
         version: 7.18.0(eslint@9.39.4)(typescript@5.9.3)
+      '@vitest/coverage-v8':
+        specifier: ^1.6.0
+        version: 1.6.1(vitest@1.6.1(@types/node@20.19.39))
       eslint:
         specifier: ^9.0.0
         version: 9.39.4
@@ -53,6 +56,30 @@ importers:
         version: 1.6.1(@types/node@20.19.39)
 
 packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@bufbuild/buf-darwin-arm64@1.68.2':
     resolution: {integrity: sha512-OCO5/2Rwif8BSB+iTZstYoWP+U3Shof32s9GDh8Q0U0KGOnGsifnrFUZCcmsJw65p3ekOMmlRk5rN0I7QhPCoQ==}
@@ -309,12 +336,26 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
@@ -558,6 +599,11 @@ packages:
   '@typescript-eslint/visitor-keys@7.18.0':
     resolution: {integrity: sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==}
     engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@vitest/coverage-v8@1.6.1':
+    resolution: {integrity: sha512-6YeRZwuO4oTGKxD3bijok756oktHSIm3eczVVzNe3scqzuhLwltIF3S9ZL/vwOVIpURmU6SnZhziXXAfw8/Qlw==}
+    peerDependencies:
+      vitest: 1.6.1
 
   '@vitest/expect@1.6.1':
     resolution: {integrity: sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==}
@@ -830,6 +876,9 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -865,6 +914,10 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -895,6 +948,9 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
@@ -910,6 +966,13 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -933,6 +996,22 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
@@ -979,6 +1058,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1032,6 +1118,9 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
@@ -1059,6 +1148,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1259,6 +1352,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
@@ -1394,6 +1491,9 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -1415,6 +1515,26 @@ packages:
     engines: {node: '>=12.20'}
 
 snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@0.2.3': {}
 
   '@bufbuild/buf-darwin-arm64@1.68.2':
     optional: true
@@ -1592,11 +1712,25 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@istanbuljs/schema@0.1.6': {}
+
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.10
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
@@ -1802,6 +1936,25 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       eslint-visitor-keys: 3.4.3
+
+  '@vitest/coverage-v8@1.6.1(vitest@1.6.1(@types/node@20.19.39))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      test-exclude: 6.0.0
+      vitest: 1.6.1(@types/node@20.19.39)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@1.6.1':
     dependencies:
@@ -2125,6 +2278,8 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
@@ -2162,6 +2317,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
   globals@14.0.0: {}
 
   globby@11.1.0:
@@ -2187,6 +2351,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-escaper@2.0.2: {}
+
   human-signals@5.0.0: {}
 
   ignore@5.3.2: {}
@@ -2197,6 +2363,13 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
 
   is-extglob@2.1.1: {}
 
@@ -2211,6 +2384,27 @@ snapshots:
   is-stream@3.0.0: {}
 
   isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
 
   js-tokens@9.0.1: {}
 
@@ -2256,6 +2450,16 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
+
   math-intrinsics@1.1.0: {}
 
   merge-stream@2.0.0: {}
@@ -2298,6 +2502,10 @@ snapshots:
 
   on-exit-leak-free@2.1.2: {}
 
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
@@ -2328,6 +2536,8 @@ snapshots:
       callsites: 3.1.0
 
   path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -2543,6 +2753,12 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  test-exclude@6.0.0:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 7.2.3
+      minimatch: 3.1.5
+
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
@@ -2669,6 +2885,8 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrappy@1.0.2: {}
 
   y18n@5.0.8: {}
 

--- a/src/application/use_cases/escrow.ts
+++ b/src/application/use_cases/escrow.ts
@@ -11,7 +11,6 @@
 // =============================================================================
 
 import {
-  Money,
   createEscrow,
   transitionEscrow,
   DisputeOngoingError,
@@ -26,6 +25,7 @@ import {
   type IdempotencyKey,
   type IdempotencyPort,
   type MilestoneCondition,
+  type Money,
   type Result,
 } from '../../domain/index.js';
 
@@ -194,14 +194,9 @@ export const makeReleaseEscrow =
     // settled. For partial releases, the gateway replies with
     // `status === 'held'` and the escrow stays in the same state.
     const advanced = applyEscrowStatus(existing, gatewayResult.status);
-    // The domain's `createEscrow` initializes `releasedAmount` as a plain
-    // object literal rather than a real `Money` instance, so `.add()` is
-    // unavailable. We sum amounts directly and rebuild the `Money` via the
-    // smart constructor to restore instance methods.
-    const releasedAccum = Money.of(
-      existing.releasedAmount.amountMinor + gatewayResult.releasedAmount.amountMinor,
-      existing.releasedAmount.currency,
-    );
+    // `createEscrow` now returns a real `Money` instance for `releasedAmount`,
+    // so `.add()` is safe. Cross-currency addition throws inside the VO.
+    const releasedAccum = existing.releasedAmount.add(gatewayResult.releasedAmount);
     const persisted: Escrow = { ...advanced, releasedAmount: releasedAccum };
     await deps.repo.save(persisted);
     const out: ReleaseEscrowOutput = {

--- a/src/domain/entities/escrow.ts
+++ b/src/domain/entities/escrow.ts
@@ -25,7 +25,7 @@
 import { DisputeOngoingError, InvalidStateTransitionError } from '../errors.js';
 import type { GatewayRef } from '../value_objects/opaque-refs.js';
 import type { IdempotencyKey } from '../value_objects/idempotency-key.js';
-import type { Money } from '../value_objects/money.js';
+import { Money } from '../value_objects/money.js';
 
 export type EscrowStatus = 'held' | 'released' | 'refunded' | 'disputed';
 
@@ -89,7 +89,11 @@ export interface CreateEscrowInput {
  * so `held` is the only legal initial status.
  */
 export function createEscrow(input: CreateEscrowInput): Escrow {
-  const zero = { amountMinor: 0n, currency: input.amount.currency } as Money;
+  // `Money.of` returns a real value object with `.add`/`.subtract`/… so the
+  // escrow's `releasedAmount` is usable by downstream accumulators without a
+  // rebuild. Earlier versions cast a plain literal which stripped the
+  // prototype — see ReleaseEscrow history for the workaround this replaces.
+  const zero = Money.of(0n, input.amount.currency);
   return {
     id: input.id,
     consumer: input.consumer,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,19 @@
 // =============================================================================
 // Entry point — payments-core sidecar.
 // -----------------------------------------------------------------------------
-// Reads env, wires a use-case container against STUB ports (real adapters
-// land in issues #20/#21), starts the gRPC server on `0.0.0.0:${GRPC_PORT}`,
-// and installs SIGTERM/SIGINT handlers for graceful shutdown.
+// Reads env, wires a use-case container against real outbound adapters where
+// env-provided credentials allow (`stripe`, `onvopay` for payments,
+// subscriptions, and webhook verification) and falls back to `UNAVAILABLE`
+// stubs for every other gateway or port that lacks a real implementation
+// (`EscrowPort`, `PayoutPort`, `AgenticPaymentPort`, `ReconciliationPort`,
+// `FXRatePort`). Starts the gRPC server on `0.0.0.0:${GRPC_PORT}` and
+// installs SIGTERM/SIGINT handlers for graceful shutdown.
 //
-// The stub ports return `GatewayUnavailableError` on every mutating call so
-// the sidecar is honest about what v1 can do. The server is still useful:
-// callers can probe it, run health checks, and observe the full proto
-// contract via reflection-compatible tooling (grpcurl with a descriptor set).
+// Missing adapter env vars are NOT fatal. The sidecar boots with a minimal
+// set; requests for an unconfigured gateway surface
+// `GatewayUnavailableError(gateway, 'not configured')` and translate to
+// gRPC `UNAVAILABLE`. Local dev environments without real secrets keep
+// working exactly as before.
 // =============================================================================
 
 import { randomUUID } from 'node:crypto';
@@ -53,6 +58,13 @@ import {
 } from './application/index.js';
 import { createServer } from './adapters/inbound/grpc/server.js';
 import { HealthService, ServingStatus } from './adapters/inbound/grpc/health.js';
+import {
+  type AdapterEnv,
+  buildPaymentGatewayRegistry,
+  buildSubscriptionPortRegistry,
+  buildWebhookVerifierRegistry,
+  makeResolver,
+} from './main/gateway-registry.js';
 
 // ---------------------------------------------------------------------------
 // Env parsing — refuse to start if required values are missing or malformed.
@@ -62,6 +74,7 @@ interface Env {
   readonly grpcPort: number;
   readonly logLevel: pino.Level;
   readonly shutdownDeadlineMs: number;
+  readonly adapters: AdapterEnv;
 }
 
 function loadEnv(): Env {
@@ -87,40 +100,59 @@ function loadEnv(): Env {
   if (!Number.isFinite(deadline) || deadline <= 0) {
     throw new Error(`SHUTDOWN_DEADLINE_MS must be > 0; got '${deadlineRaw}'`);
   }
-  return { grpcPort: port, logLevel, shutdownDeadlineMs: deadline };
+  // Adapter env vars are optional at the process level. Unset values mean
+  // the corresponding gateway will not be registered; requests for it return
+  // `UNAVAILABLE` until secrets are provided.
+  const adapters: AdapterEnv = {
+    ...(process.env['STRIPE_SECRET_KEY'] !== undefined
+      ? { stripeSecretKey: process.env['STRIPE_SECRET_KEY'] }
+      : {}),
+    ...(process.env['STRIPE_WEBHOOK_SIGNING_SECRET'] !== undefined
+      ? { stripeWebhookSigningSecret: process.env['STRIPE_WEBHOOK_SIGNING_SECRET'] }
+      : {}),
+    ...(process.env['ONVOPAY_API_KEY'] !== undefined
+      ? { onvopayApiKey: process.env['ONVOPAY_API_KEY'] }
+      : {}),
+    ...(process.env['ONVOPAY_API_BASE_URL'] !== undefined
+      ? { onvopayApiBaseUrl: process.env['ONVOPAY_API_BASE_URL'] }
+      : {}),
+    ...(process.env['ONVOPAY_WEBHOOK_SIGNING_SECRET'] !== undefined
+      ? {
+          onvopayWebhookSigningSecret:
+            process.env['ONVOPAY_WEBHOOK_SIGNING_SECRET'],
+        }
+      : {}),
+  };
+  return {
+    grpcPort: port,
+    logLevel,
+    shutdownDeadlineMs: deadline,
+    adapters,
+  };
 }
 
 // ---------------------------------------------------------------------------
 // Stub port implementations
 // -----------------------------------------------------------------------------
-// Every stub throws `GatewayUnavailableError`; the server maps that to gRPC
-// `UNAVAILABLE`, which is the correct signal to callers ("capability not
-// live yet"). Stubs are identity-tagged `'stripe'` so failure messages carry
-// a concrete gateway name.
+// Retained only for ports that do NOT have a real outbound adapter yet
+// (`EscrowPort`, `PayoutPort`, `AgenticPaymentPort`, `ReconciliationPort`,
+// `FXRatePort`). Each throws `GatewayUnavailableError`, which the inbound
+// gRPC translator maps to `UNAVAILABLE`. Ports that DO have adapters
+// (`PaymentGatewayPort`, `SubscriptionPort`, `WebhookVerifierPort`) are
+// served by the registry; their per-gateway stub, used when the requested
+// gateway has no env credentials, lives in `buildUseCasesInternal`.
 // ---------------------------------------------------------------------------
 
 const STUB_GATEWAY: GatewayName = 'stripe';
-const STUB_REASON = 'stub port: real adapter pending (see issues #20/#21)';
+const STUB_REASON = 'stub port: real adapter pending';
 
 function unavailable(): never {
   throw new GatewayUnavailableError(STUB_GATEWAY, STUB_REASON);
 }
 
-const stubPaymentGateway: PaymentGatewayPort = {
-  gateway: STUB_GATEWAY,
-  initiate: () => unavailable(),
-  confirm: () => unavailable(),
-  capture: () => unavailable(),
-  refund: () => unavailable(),
-};
-
-const stubSubscriptionGateway: SubscriptionPort = {
-  gateway: STUB_GATEWAY,
-  create: () => unavailable(),
-  switch: () => unavailable(),
-  cancel: () => unavailable(),
-  prorate: () => unavailable(),
-};
+function unavailableFor(gateway: GatewayName): never {
+  throw new GatewayUnavailableError(gateway, 'not configured');
+}
 
 const stubEscrowGateway: EscrowPort = {
   gateway: STUB_GATEWAY,
@@ -132,11 +164,6 @@ const stubEscrowGateway: EscrowPort = {
 const stubPayoutGateway: PayoutGatewayPort = {
   gateway: STUB_GATEWAY,
   createPayout: () => unavailable(),
-};
-
-const stubWebhookVerifier: WebhookVerifierPort = {
-  gateway: STUB_GATEWAY,
-  verify: () => unavailable(),
 };
 
 const stubAgentic: AgenticPaymentPort = {
@@ -151,6 +178,36 @@ const stubReconciliation: ReconciliationPort = {
 const stubFx: FXRatePort = {
   lookup: () => unavailable(),
 };
+
+// Per-gateway stubs for the three wired ports. Only constructed when a
+// caller asks for a gateway that hasn't been registered; the stub carries
+// the requested gateway name so the error message is accurate.
+function stubPaymentGatewayFor(gateway: GatewayName): PaymentGatewayPort {
+  return {
+    gateway,
+    initiate: () => unavailableFor(gateway),
+    confirm: () => unavailableFor(gateway),
+    capture: () => unavailableFor(gateway),
+    refund: () => unavailableFor(gateway),
+  };
+}
+
+function stubSubscriptionPortFor(gateway: GatewayName): SubscriptionPort {
+  return {
+    gateway,
+    create: () => unavailableFor(gateway),
+    switch: () => unavailableFor(gateway),
+    cancel: () => unavailableFor(gateway),
+    prorate: () => unavailableFor(gateway),
+  };
+}
+
+function stubWebhookVerifierFor(gateway: GatewayName): WebhookVerifierPort {
+  return {
+    gateway,
+    verify: () => unavailableFor(gateway),
+  };
+}
 
 // ---------------------------------------------------------------------------
 // In-memory stores (swap for real infra in a later change)
@@ -215,23 +272,40 @@ class InMemoryPayoutRepo {
 // Wire + start
 // ---------------------------------------------------------------------------
 
-function buildUseCases(): ReturnType<typeof buildUseCasesInternal> {
-  return buildUseCasesInternal();
+export function buildUseCases(
+  env: AdapterEnv,
+): ReturnType<typeof buildUseCasesInternal> {
+  return buildUseCasesInternal(env);
 }
 
-function buildUseCasesInternal() {
+function buildUseCasesInternal(env: AdapterEnv) {
   const idempotency = new InMemoryIdempotency();
   const intentRepo = new InMemoryPaymentIntentRepo();
   const subRepo = new InMemorySubscriptionRepo();
   const escrowRepo = new InMemoryEscrowRepo();
   const payoutRepo = new InMemoryPayoutRepo();
 
+  // Real adapters constructed from env; unconfigured gateways fall through
+  // to per-gateway stubs that return `UNAVAILABLE` on every call.
+  const paymentRegistry = buildPaymentGatewayRegistry(env);
+  const subscriptionRegistry = buildSubscriptionPortRegistry(env);
+  const webhookVerifierRegistry = buildWebhookVerifierRegistry(env, idempotency);
+
+  const resolvePayment = makeResolver(paymentRegistry, stubPaymentGatewayFor);
+  const resolveSubscription = makeResolver(
+    subscriptionRegistry,
+    stubSubscriptionPortFor,
+  );
+  const resolveVerifier = makeResolver(
+    webhookVerifierRegistry,
+    stubWebhookVerifierFor,
+  );
+
   const paymentGateways = {
-    resolvePaymentGateway: (_g: GatewayName): PaymentGatewayPort => stubPaymentGateway,
+    resolvePaymentGateway: resolvePayment,
   };
   const subscriptionGateways = {
-    resolveSubscriptionGateway: (_g: GatewayName): SubscriptionPort =>
-      stubSubscriptionGateway,
+    resolveSubscriptionGateway: resolveSubscription,
   };
   const escrowGateways = {
     resolveEscrowGateway: (_g: GatewayName): EscrowPort => stubEscrowGateway,
@@ -240,7 +314,7 @@ function buildUseCasesInternal() {
     resolvePayoutGateway: (_g: GatewayName): PayoutGatewayPort => stubPayoutGateway,
   };
   const verifierRegistry = {
-    resolveVerifier: (_g: GatewayName): WebhookVerifierPort => stubWebhookVerifier,
+    resolveVerifier,
   };
   const reconciliationRegistry = {
     listReconciliationPorts: (): readonly ReconciliationPort[] => [stubReconciliation],
@@ -326,7 +400,7 @@ void createGatewayRef;
 export async function main(): Promise<void> {
   const env = loadEnv();
   const logger = pino({ level: env.logLevel });
-  const useCases = buildUseCases();
+  const useCases = buildUseCases(env.adapters);
   const health = new HealthService(ServingStatus.NOT_SERVING);
 
   const { server } = createServer({

--- a/src/main/gateway-registry.ts
+++ b/src/main/gateway-registry.ts
@@ -1,0 +1,185 @@
+// =============================================================================
+// Gateway registry — composition-root helpers.
+// -----------------------------------------------------------------------------
+// Turns env-sourced credentials into a set of ready-to-use outbound adapters,
+// keyed by `GatewayName`. The composition root (`src/main.ts`) wires these
+// into the use-case factories; adapters without real implementations yet
+// (`EscrowPort`, `PayoutPort`, …) keep their stub fallbacks there.
+//
+// Design choices:
+//   - An adapter is only registered when its env vars are present. A missing
+//     key means the sidecar still boots; requests for that specific gateway
+//     surface `GatewayUnavailableError('<name>', 'not configured')` and map
+//     to gRPC `UNAVAILABLE`. Dev environments without real secrets keep
+//     working.
+//   - Each port has its own registry map. A caller can legitimately want
+//     Stripe for payments but reuse the shared `IdempotencyPort` for webhook
+//     dedupe on both gateways. Splitting avoids a single giant factory.
+//   - No fallbacks between gateways. An explicit `stripe` request never
+//     silently routes to `onvopay` and vice versa.
+// =============================================================================
+
+import {
+  type GatewayName,
+  type IdempotencyPort,
+  type PaymentGatewayPort,
+  type SubscriptionPort,
+  type WebhookVerifierPort,
+} from '../domain/index.js';
+import {
+  OnvoPayPaymentGateway,
+  OnvoPaySubscriptionGateway,
+  OnvoPayWebhookVerifier,
+  InMemoryOnvoPayDedupeStore,
+  createOnvoPayHttpClient,
+} from '../adapters/outbound/gateways/onvopay/index.js';
+import {
+  StripePaymentGateway,
+  StripeSubscriptionAdapter,
+  StripeWebhookVerifier,
+  createStripeClient,
+} from '../adapters/outbound/gateways/stripe/index.js';
+
+/**
+ * Subset of the process env relevant to outbound-adapter construction. The
+ * composition root parses `process.env` once, validates required pieces, and
+ * hands a frozen copy to the registry builders. Tests construct this shape
+ * directly to avoid mutating `process.env`.
+ */
+export interface AdapterEnv {
+  readonly stripeSecretKey?: string;
+  readonly stripeWebhookSigningSecret?: string;
+  readonly onvopayApiKey?: string;
+  readonly onvopayApiBaseUrl?: string;
+  readonly onvopayWebhookSigningSecret?: string;
+}
+
+/**
+ * Build the `PaymentGatewayPort` registry. Only adapters whose env vars are
+ * present are registered. An empty map is a valid outcome — it means every
+ * real payment gateway will return `UNAVAILABLE` until secrets are supplied.
+ */
+export function buildPaymentGatewayRegistry(
+  env: AdapterEnv,
+): Map<GatewayName, PaymentGatewayPort> {
+  const map = new Map<GatewayName, PaymentGatewayPort>();
+
+  if (typeof env.stripeSecretKey === 'string' && env.stripeSecretKey.length > 0) {
+    const client = createStripeClient({ secretKey: env.stripeSecretKey });
+    map.set('stripe', new StripePaymentGateway({ client }));
+  }
+
+  if (
+    typeof env.onvopayApiKey === 'string' &&
+    env.onvopayApiKey.length > 0 &&
+    typeof env.onvopayApiBaseUrl === 'string' &&
+    env.onvopayApiBaseUrl.length > 0
+  ) {
+    const http = createOnvoPayHttpClient({
+      apiKey: env.onvopayApiKey,
+      apiBaseUrl: env.onvopayApiBaseUrl,
+    });
+    map.set('onvopay', new OnvoPayPaymentGateway(http));
+  }
+
+  return map;
+}
+
+/**
+ * Build the `SubscriptionPort` registry. Same contract as the payment-gateway
+ * builder — only adapters with env keys land in the map.
+ */
+export function buildSubscriptionPortRegistry(
+  env: AdapterEnv,
+): Map<GatewayName, SubscriptionPort> {
+  const map = new Map<GatewayName, SubscriptionPort>();
+
+  if (typeof env.stripeSecretKey === 'string' && env.stripeSecretKey.length > 0) {
+    const client = createStripeClient({ secretKey: env.stripeSecretKey });
+    map.set('stripe', new StripeSubscriptionAdapter({ client }));
+  }
+
+  if (
+    typeof env.onvopayApiKey === 'string' &&
+    env.onvopayApiKey.length > 0 &&
+    typeof env.onvopayApiBaseUrl === 'string' &&
+    env.onvopayApiBaseUrl.length > 0
+  ) {
+    const http = createOnvoPayHttpClient({
+      apiKey: env.onvopayApiKey,
+      apiBaseUrl: env.onvopayApiBaseUrl,
+    });
+    map.set('onvopay', new OnvoPaySubscriptionGateway(http));
+  }
+
+  return map;
+}
+
+/**
+ * Build the `WebhookVerifierPort` registry. Requires the matching signing
+ * secret as well as the API key — a verifier without its signing secret has
+ * no way to validate payloads.
+ *
+ * Stripe's verifier reuses the application-layer `IdempotencyPort` for
+ * duplicate-event detection until a dedicated `WebhookEventRepositoryPort`
+ * lands. OnvoPay's verifier ships with its own in-memory dedupe store — a
+ * multi-process deployment should swap that for Redis/Postgres later.
+ */
+export function buildWebhookVerifierRegistry(
+  env: AdapterEnv,
+  idempotency: IdempotencyPort,
+): Map<GatewayName, WebhookVerifierPort> {
+  const map = new Map<GatewayName, WebhookVerifierPort>();
+
+  if (
+    typeof env.stripeSecretKey === 'string' &&
+    env.stripeSecretKey.length > 0 &&
+    typeof env.stripeWebhookSigningSecret === 'string' &&
+    env.stripeWebhookSigningSecret.length > 0
+  ) {
+    const client = createStripeClient({ secretKey: env.stripeSecretKey });
+    map.set(
+      'stripe',
+      new StripeWebhookVerifier({
+        client,
+        signingSecret: env.stripeWebhookSigningSecret,
+        idempotency,
+      }),
+    );
+  }
+
+  if (
+    typeof env.onvopayWebhookSigningSecret === 'string' &&
+    env.onvopayWebhookSigningSecret.length > 0
+  ) {
+    map.set(
+      'onvopay',
+      new OnvoPayWebhookVerifier({
+        signingSecret: env.onvopayWebhookSigningSecret,
+        dedupe: new InMemoryOnvoPayDedupeStore(),
+      }),
+    );
+  }
+
+  return map;
+}
+
+/**
+ * Dispatcher factory — returns a resolver that honors the registry contract:
+ * present → real adapter; absent → stub that raises `GatewayUnavailableError`.
+ *
+ * Callers pass a `stubFactory` so the caller decides whether an unconfigured
+ * slot is a fatal error (production) or a predictable `UNAVAILABLE` response
+ * (local dev). The stub factory receives the requested `GatewayName` so the
+ * resulting error message can be specific.
+ */
+export function makeResolver<P>(
+  registry: ReadonlyMap<GatewayName, P>,
+  stubFactory: (gateway: GatewayName) => P,
+): (gateway: GatewayName) => P {
+  return (gateway: GatewayName): P => {
+    const adapter = registry.get(gateway);
+    if (adapter !== undefined) return adapter;
+    return stubFactory(gateway);
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,10 @@ export default defineConfig({
   test: {
     include: ['test/**/*.{test,spec}.ts', 'src/**/*.{test,spec}.ts'],
     coverage: {
-      reporter: ['text-summary'],
+      provider: 'v8',
+      reporter: ['text-summary', 'lcov'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/generated/**', 'src/main.ts'],
     },
   },
 });


### PR DESCRIPTION
Closes #40

Post-ola-final cleanup micro-PR — four concerns in one small, reviewable change. Bundled at maintainer request after the /pending-left audit across PRs #22 / #23 / #25 / #26.

## Concerns resolved

### A. Orphan local branch (housekeeping)

`docs/expand-openspec-change-stubs` was merged via PR #3 but the local ref was never cleaned up. Deleted in the maintainer's worktree before implementation. No remote impact.

### B. Domain bug: `src/domain/entities/escrow.ts:92`

`createEscrow` initialised `releasedAmount` as a plain object literal cast to `Money`, which stripped the prototype (`.add`, `.subtract`, …). `ReleaseEscrow` had a workaround that rebuilt the value via `Money.of(...)` before calling `.add()`.

- `createEscrow` now uses `Money.of(0n, input.amount.currency)` so the returned entity carries a real `Money` instance.
- The workaround in `ReleaseEscrow` was removed (`existing.releasedAmount.add(gatewayResult.releasedAmount)` is now the canonical form).

### C. `@vitest/coverage-v8` devDep + `lcov` reporter

Flagged on PRs #22 and #23. `vitest.config.ts` referenced `coverage.reporter` but no provider was installed, so `pnpm test -- --coverage` failed.

- Added `@vitest/coverage-v8@^1.6.0` (matches installed `vitest@1.6.1`).
- `vitest.config.ts` now declares the `v8` provider and emits `text-summary` + `lcov`.
- `pnpm test -- --coverage` produces `coverage/lcov.info` consumable by CI.
- Coverage thresholds intentionally NOT enforced yet — separate follow-up.

### D. GatewayRegistry wire (P0 blocker)

`src/main.ts` wired `PaymentGatewayPort`, `SubscriptionPort`, and `WebhookVerifierPort` as stubs throwing `GatewayUnavailableError('stub port: real adapter pending')`. The Stripe (#25) and OnvoPay (#24) adapters are now landed, so this PR replaces the stubs with a registry.

- New `src/main/gateway-registry.ts` exposes `buildPaymentGatewayRegistry`, `buildSubscriptionPortRegistry`, `buildWebhookVerifierRegistry`, and a generic `makeResolver<P>(registry, stubFactory)` helper.
- Adapters are only registered when their env vars are present; missing keys are not fatal. Requests for an unconfigured gateway surface `GatewayUnavailableError(<gateway>, 'not configured')`, which the inbound translator maps to gRPC `UNAVAILABLE`. Dev environments without real secrets keep booting.
- `buildUseCases(env)` is now `export`ed and takes an `AdapterEnv` argument; `loadEnv` builds that from the process env.
- `EscrowPort`, `PayoutPort`, `AgenticPaymentPort`, `ReconciliationPort`, `FXRatePort` keep their stub fallbacks — they have no real adapters yet.

## OpenSpec

Appended a `## Post-merge cleanup (landed in PR #41)` section to `openspec/changes/grpc-server-inbound/tasks.md` documenting the four items so the stub-to-real wire is traceable from the inbound-gRPC change.

## Verification

Local, all green:

```
pnpm install
pnpm lint
pnpm build
pnpm test                  # 174 tests across 14 files
pnpm test -- --coverage    # coverage/lcov.info produced
docker build -t payments-core:cleanup-test .
```

Touched ~8 files (7 modified + 1 new), within the 15-file rule.

## Scope

- `src/domain/entities/escrow.ts` — Money factory fix
- `src/application/use_cases/escrow.ts` — workaround removal
- `src/main.ts` — env loader + registry wiring + per-gateway stub fallbacks
- `src/main/gateway-registry.ts` — new, registry builders + resolver
- `package.json` / `pnpm-lock.yaml` — `@vitest/coverage-v8` devDep
- `vitest.config.ts` — v8 provider + lcov
- `openspec/changes/grpc-server-inbound/tasks.md` — post-merge notes

Created by Claude Code on behalf of @lapc506