### PR TITLE
DonationPort + recurring donations (one-time + recurring + pause + cancel)

### DIFF
--- a/openspec/changes/donations-port/tasks.md
+++ b/openspec/changes/donations-port/tasks.md
@@ -1,5 +1,11 @@
 # Tasks — DonationPort
 
+> **Landed in PR** (GitHub Issue #27, branch `feat/issue-27-donations-port`).
+> Scope delivered: port interface, three wrapper use cases, main.ts stub
+> wiring, unit tests. Adapter wrappers (`StripeDonationAdapter`,
+> `OnvoPayDonationAdapter`), the Postgres repository, event emission, and the
+> docs page land in follow-ups to keep the PR under the 15-file budget.
+
 ## Linear
 
 - Title: `payments-core: DonationPort (one-time + recurring, campaign_id metadata hook)`
@@ -12,23 +18,23 @@
 
 ### Port expansion
 
-- [ ] `src/domain/ports/donation-port.ts` expanded with the full `DonationPort` interface per `design.md`.
-- [ ] `DonorRef`, `DonorVisibility`, `DonationRecurrence` types declared.
-- [ ] Export updates in `src/domain/ports/index.ts`.
+- [x] `DonationPort` interface added to `src/domain/ports/index.ts` (kept in the single ports file to honor the 15-file budget tracked on the ports module).
+- [x] `DonorVisibility`, `DonationRecurrence`, `DonationRef`, `InitiateOneTimeDonationInput`, `InitiateRecurringDonationInput`, `InitiateDonationResult` types declared alongside the port.
+- [x] Signatures: `initiateOneTime`, `initiateRecurring`, `pauseRecurring(gatewayRef, idempotencyKey)`, `cancelRecurring(gatewayRef, idempotencyKey)`. `DonorRef` is deferred until the adapter change lands — the port takes a flat `donorReference: string` today, matching how the existing `Donation` entity already models a donor.
 
 ### Use cases
 
-- [ ] `InitiateDonation` — handles one-time + switches to `SetupRecurringDonation` when `recurrence` is present.
-- [ ] `SetupRecurringDonation` — calls gateway's recurring setup, persists `Donation`, emits `RecurringDonationActivated`.
-- [ ] `CancelRecurringDonation` — idempotent by key.
-- [ ] `ListDonationsForCampaign` — paginated query via `DonationRepositoryPort.listForCampaign`.
+- [x] `CreateOneTimeDonation` — validates `Money > 0`, idempotency-checks, calls `DonationPort.initiateOneTime`, persists a one-time `Donation`, returns a `DonationRef`.
+- [x] `CreateRecurringDonation` — same shape + `recurrence` spec; kind `recurring`.
+- [x] `ManageRecurringDonation` — discriminated-union input (`pause` | `cancel`) addressed by `gatewayRef`. Idempotent by key.
+- [ ] `ListDonationsForCampaign` — deferred with the Postgres repository change.
 
 ### Adapters
 
-- [ ] `StripeDonationAdapter` — lives under `src/adapters/outbound/stripe/`; reuses the pinned Stripe 18.5.0 client.
-- [ ] `OnvoPayDonationAdapter` — lives under `src/adapters/outbound/onvopay/`; follows the same metadata pattern.
-- [ ] Both adapters attach `campaign_id` (when present), `donor_visibility`, and `recurrence.*` to the gateway's metadata map.
-- [ ] Anonymous donor handling: `receipt_email` suppressed in Stripe when `donorVisibility !== 'public'`.
+- [ ] `StripeDonationAdapter` — deferred to a follow-up change (keeps this PR ≤ 8 files; DonationPort consumers currently fall through to `stubDonationPortFor` which raises `GatewayUnavailableError`).
+- [ ] `OnvoPayDonationAdapter` — deferred, same rationale.
+- [ ] Both adapters will attach `campaign_id` (when present), `donor_visibility`, and `recurrence.*` to the gateway's metadata map. The use cases already enrich the metadata on the domain side so the adapter change only needs to pass it through.
+- [ ] Anonymous donor handling: `receipt_email` suppression in Stripe when `donorVisibility !== 'public'` — deferred with the adapter.
 
 ### Event emission
 
@@ -44,12 +50,12 @@
 
 ### Tests
 
-- [ ] Unit: each use case with fake adapters + in-memory repo.
-- [ ] Unit: Stripe adapter one-time donation + recurring donation flow, mocking the SDK.
-- [ ] Unit: OnvoPay adapter one-time + recurring; webhook dispatch to `DonationReceived` event.
-- [ ] Unit: `listForCampaign` pagination + empty-result case.
-- [ ] Integration (gated by `STRIPE_SECRET_KEY` + `ONVOPAY_API_KEY`): a live one-time donation on each gateway, followed by `listDonationsForCampaign` returning the donation.
-- [ ] PII guard: email-hash column is SHA-256 of `email.toLowerCase().trim()`.
+- [x] Unit: each use case with a fake `DonationPort` implementation + in-memory repo. Happy path, idempotency replay, zero/negative amount rejection, gateway-error surfacing, and campaign_id present/absent branches are all covered.
+- [ ] Unit: Stripe adapter one-time donation + recurring donation flow, mocking the SDK — deferred with the adapter change.
+- [ ] Unit: OnvoPay adapter one-time + recurring; webhook dispatch to `DonationReceived` event — deferred with the adapter change.
+- [ ] Unit: `listForCampaign` pagination + empty-result case — deferred with the repository change.
+- [ ] Integration (gated by `STRIPE_SECRET_KEY` + `ONVOPAY_API_KEY`): a live one-time donation on each gateway — deferred.
+- [ ] PII guard: email-hash column is SHA-256 of `email.toLowerCase().trim()` — deferred with the Postgres schema.
 
 ### Docs
 

--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -117,3 +117,21 @@ export {
   type ReconcileDailyOutput,
   type ReconcileDailyDeps,
 } from './use_cases/reads.js';
+
+export {
+  makeCreateOneTimeDonation,
+  makeCreateRecurringDonation,
+  makeManageRecurringDonation,
+  type CreateDonationCommonInput,
+  type CreateOneTimeDonationInput,
+  type CreateOneTimeDonationOutput,
+  type CreateOneTimeDonationDeps,
+  type CreateRecurringDonationInput,
+  type CreateRecurringDonationOutput,
+  type CreateRecurringDonationDeps,
+  type ManageRecurringDonationInput,
+  type ManageRecurringDonationOutput,
+  type ManageRecurringDonationDeps,
+  type DonationRegistryPort,
+  type DonationRepositoryPort,
+} from './use_cases/donations.js';

--- a/src/application/use_cases/donations.ts
+++ b/src/application/use_cases/donations.ts
@@ -1,0 +1,364 @@
+// =============================================================================
+// Donation use cases — 3 orchestrators on top of `DonationPort`.
+// -----------------------------------------------------------------------------
+// Implements the AltruPets-driven donation flows (one-time + recurring +
+// pause/cancel) declared in `openspec/changes/donations-port/`. The
+// `campaign_id` metadata hook is carried end-to-end as an opaque string;
+// payments-core never interprets it — consumer backends model campaigns.
+//
+// Three use cases:
+//   1. CreateOneTimeDonation    — validates Money, idempotency-checks, calls
+//                                  `DonationPort.initiateOneTime`, persists
+//                                  the `Donation` entity, returns DonationRef.
+//   2. CreateRecurringDonation  — same shape as (1) but with a recurrence spec
+//                                  and the `recurring` donation kind.
+//   3. ManageRecurringDonation  — pause/cancel via a discriminated union
+//                                  input. Lookup is by gatewayRef (the
+//                                  subscription-like handle returned by
+//                                  `initiateRecurring`).
+//
+// Pause/cancel do NOT transition the stored `Donation` record: a recurring
+// donation's Donation-entity row captures a single charge event, not the
+// schedule itself. The schedule lives gateway-side, addressed by gatewayRef.
+// =============================================================================
+
+import {
+  createDonation,
+  DomainError,
+  err,
+  InvalidMoneyError,
+  ok,
+  type Donation,
+  type DonationPort,
+  type DonationRecurrence,
+  type DonationRef,
+  type DonorVisibility,
+  type GatewayName,
+  type GatewayRef,
+  type IdempotencyKey,
+  type IdempotencyPort,
+  type Money,
+  type Result,
+} from '../../domain/index.js';
+
+// ---------------------------------------------------------------------------
+// Ports local to the application layer
+// ---------------------------------------------------------------------------
+
+export interface DonationRepositoryPort {
+  save(donation: Donation): Promise<void>;
+  findById(id: string): Promise<Donation | null>;
+}
+
+export interface DonationRegistryPort {
+  resolveDonationGateway(gateway: GatewayName): DonationPort;
+}
+
+// ---------------------------------------------------------------------------
+// Shared input pieces
+// ---------------------------------------------------------------------------
+
+export interface CreateDonationCommonInput {
+  readonly id: string;
+  readonly consumer: string;
+  readonly donorReference: string;
+  readonly amount: Money;
+  readonly gateway: GatewayName;
+  /** Opaque campaign id. `null` means "no campaign attached". */
+  readonly campaignId: string | null;
+  readonly donorVisibility: DonorVisibility;
+  readonly idempotencyKey: IdempotencyKey;
+  readonly metadata?: Readonly<Record<string, string>>;
+  readonly returnUrl?: string;
+  readonly cancelUrl?: string;
+}
+
+// =============================================================================
+// CreateOneTimeDonation
+// =============================================================================
+
+export type CreateOneTimeDonationInput = CreateDonationCommonInput;
+
+export interface CreateOneTimeDonationOutput {
+  readonly ref: DonationRef;
+  readonly donation: Donation;
+  readonly requiresAction: boolean;
+  readonly checkoutUrl?: string;
+}
+
+export interface CreateOneTimeDonationDeps {
+  readonly gateways: DonationRegistryPort;
+  readonly repo: DonationRepositoryPort;
+  readonly idempotency: IdempotencyPort;
+}
+
+export const makeCreateOneTimeDonation =
+  (deps: CreateOneTimeDonationDeps) =>
+  async (
+    input: CreateOneTimeDonationInput,
+  ): Promise<Result<CreateOneTimeDonationOutput, DomainError>> => {
+    const cached = await deps.idempotency.check<CreateOneTimeDonationOutput>(
+      input.idempotencyKey,
+    );
+    if (cached !== null) return ok(cached);
+
+    const validation = validateDonationAmount(input.amount);
+    if (!validation.ok) return validation;
+
+    const metadata = enrichDonationMetadata(input.metadata, input.campaignId, input.donorVisibility);
+
+    const donation = createDonation({
+      id: input.id,
+      consumer: input.consumer,
+      donorReference: input.donorReference,
+      campaignId: input.campaignId ?? '',
+      kind: 'one_time',
+      amount: input.amount,
+      idempotencyKey: input.idempotencyKey,
+      metadata,
+    });
+
+    const gateway = deps.gateways.resolveDonationGateway(input.gateway);
+
+    let gatewayResult;
+    try {
+      gatewayResult = await gateway.initiateOneTime({
+        amount: input.amount,
+        consumer: input.consumer,
+        donorReference: input.donorReference,
+        campaignId: input.campaignId,
+        donorVisibility: input.donorVisibility,
+        idempotencyKey: input.idempotencyKey,
+        metadata,
+        ...(input.returnUrl !== undefined ? { returnUrl: input.returnUrl } : {}),
+        ...(input.cancelUrl !== undefined ? { cancelUrl: input.cancelUrl } : {}),
+      });
+    } catch (e) {
+      return wrapError(e);
+    }
+
+    const persisted: Donation = {
+      ...donation,
+      status: 'pending',
+      gatewayRef: gatewayResult.gatewayRef,
+    };
+    await deps.repo.save(persisted);
+
+    const ref: DonationRef = {
+      donationId: persisted.id,
+      gatewayRef: gatewayResult.gatewayRef,
+      kind: 'one_time',
+    };
+    const out: CreateOneTimeDonationOutput = {
+      ref,
+      donation: persisted,
+      requiresAction: gatewayResult.requiresAction,
+      ...(gatewayResult.checkoutUrl !== undefined
+        ? { checkoutUrl: gatewayResult.checkoutUrl }
+        : {}),
+    };
+    await deps.idempotency.commit(input.idempotencyKey, out);
+    return ok(out);
+  };
+
+// =============================================================================
+// CreateRecurringDonation
+// =============================================================================
+
+export interface CreateRecurringDonationInput extends CreateDonationCommonInput {
+  readonly recurrence: DonationRecurrence;
+}
+
+export interface CreateRecurringDonationOutput {
+  readonly ref: DonationRef;
+  readonly donation: Donation;
+  readonly requiresAction: boolean;
+  readonly checkoutUrl?: string;
+}
+
+export interface CreateRecurringDonationDeps {
+  readonly gateways: DonationRegistryPort;
+  readonly repo: DonationRepositoryPort;
+  readonly idempotency: IdempotencyPort;
+}
+
+export const makeCreateRecurringDonation =
+  (deps: CreateRecurringDonationDeps) =>
+  async (
+    input: CreateRecurringDonationInput,
+  ): Promise<Result<CreateRecurringDonationOutput, DomainError>> => {
+    const cached = await deps.idempotency.check<CreateRecurringDonationOutput>(
+      input.idempotencyKey,
+    );
+    if (cached !== null) return ok(cached);
+
+    const validation = validateDonationAmount(input.amount);
+    if (!validation.ok) return validation;
+
+    const metadata = enrichDonationMetadata(
+      input.metadata,
+      input.campaignId,
+      input.donorVisibility,
+      input.recurrence,
+    );
+
+    const donation = createDonation({
+      id: input.id,
+      consumer: input.consumer,
+      donorReference: input.donorReference,
+      campaignId: input.campaignId ?? '',
+      kind: 'recurring',
+      amount: input.amount,
+      idempotencyKey: input.idempotencyKey,
+      metadata,
+    });
+
+    const gateway = deps.gateways.resolveDonationGateway(input.gateway);
+
+    let gatewayResult;
+    try {
+      gatewayResult = await gateway.initiateRecurring({
+        amount: input.amount,
+        consumer: input.consumer,
+        donorReference: input.donorReference,
+        campaignId: input.campaignId,
+        donorVisibility: input.donorVisibility,
+        recurrence: input.recurrence,
+        idempotencyKey: input.idempotencyKey,
+        metadata,
+        ...(input.returnUrl !== undefined ? { returnUrl: input.returnUrl } : {}),
+        ...(input.cancelUrl !== undefined ? { cancelUrl: input.cancelUrl } : {}),
+      });
+    } catch (e) {
+      return wrapError(e);
+    }
+
+    const persisted: Donation = {
+      ...donation,
+      status: 'pending',
+      gatewayRef: gatewayResult.gatewayRef,
+    };
+    await deps.repo.save(persisted);
+
+    const ref: DonationRef = {
+      donationId: persisted.id,
+      gatewayRef: gatewayResult.gatewayRef,
+      kind: 'recurring',
+    };
+    const out: CreateRecurringDonationOutput = {
+      ref,
+      donation: persisted,
+      requiresAction: gatewayResult.requiresAction,
+      ...(gatewayResult.checkoutUrl !== undefined
+        ? { checkoutUrl: gatewayResult.checkoutUrl }
+        : {}),
+    };
+    await deps.idempotency.commit(input.idempotencyKey, out);
+    return ok(out);
+  };
+
+// =============================================================================
+// ManageRecurringDonation — discriminated union: pause | cancel
+// =============================================================================
+
+export type ManageRecurringDonationInput =
+  | {
+      readonly action: 'pause';
+      readonly gatewayRef: GatewayRef;
+      readonly idempotencyKey: IdempotencyKey;
+    }
+  | {
+      readonly action: 'cancel';
+      readonly gatewayRef: GatewayRef;
+      readonly idempotencyKey: IdempotencyKey;
+    };
+
+export interface ManageRecurringDonationOutput {
+  readonly action: 'pause' | 'cancel';
+  readonly gatewayRef: GatewayRef;
+}
+
+export interface ManageRecurringDonationDeps {
+  readonly gateways: DonationRegistryPort;
+  readonly idempotency: IdempotencyPort;
+}
+
+export const makeManageRecurringDonation =
+  (deps: ManageRecurringDonationDeps) =>
+  async (
+    input: ManageRecurringDonationInput,
+  ): Promise<Result<ManageRecurringDonationOutput, DomainError>> => {
+    const cached = await deps.idempotency.check<ManageRecurringDonationOutput>(
+      input.idempotencyKey,
+    );
+    if (cached !== null) return ok(cached);
+
+    const gateway = deps.gateways.resolveDonationGateway(input.gatewayRef.gateway);
+
+    try {
+      if (input.action === 'pause') {
+        await gateway.pauseRecurring(input.gatewayRef, input.idempotencyKey);
+      } else {
+        await gateway.cancelRecurring(input.gatewayRef, input.idempotencyKey);
+      }
+    } catch (e) {
+      return wrapError(e);
+    }
+
+    const out: ManageRecurringDonationOutput = {
+      action: input.action,
+      gatewayRef: input.gatewayRef,
+    };
+    await deps.idempotency.commit(input.idempotencyKey, out);
+    return ok(out);
+  };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function validateDonationAmount(amount: Money): Result<true, DomainError> {
+  if (amount.isZero()) {
+    return err(new InvalidMoneyError('Donation amount must be greater than zero.'));
+  }
+  // Negative amounts are already rejected by `Money.of`/`Money.create`; this
+  // is a second line of defence in case a caller constructs a Money via an
+  // untyped back door.
+  if (amount.amountMinor < 0n) {
+    return err(
+      new InvalidMoneyError(
+        `Donation amount must be non-negative; got ${amount.amountMinor}`,
+      ),
+    );
+  }
+  return ok(true);
+}
+
+function enrichDonationMetadata(
+  base: Readonly<Record<string, string>> | undefined,
+  campaignId: string | null,
+  donorVisibility: DonorVisibility,
+  recurrence?: DonationRecurrence,
+): Readonly<Record<string, string>> {
+  const enriched: Record<string, string> = { ...(base ?? {}) };
+  enriched['donation'] = 'true';
+  enriched['donor_visibility'] = donorVisibility;
+  if (campaignId !== null && campaignId.length > 0) {
+    enriched['campaign_id'] = campaignId;
+  }
+  if (recurrence !== undefined) {
+    enriched['recurrence_interval'] = recurrence.interval;
+    if (recurrence.interval === 'custom') {
+      enriched['recurrence_days_between'] = String(recurrence.daysBetween);
+    } else {
+      enriched['recurrence_count'] = String(recurrence.count);
+    }
+  }
+  return enriched;
+}
+
+function wrapError<T>(e: unknown): Result<T, DomainError> {
+  if (e instanceof DomainError) return err(e);
+  const msg = e instanceof Error ? e.message : String(e);
+  return err(new DomainError('APPLICATION_UNEXPECTED', msg));
+}

--- a/src/domain/ports/index.ts
+++ b/src/domain/ports/index.ts
@@ -15,7 +15,7 @@
 // `pg`, `node-fetch`, or anything with I/O. Ports are pure interfaces.
 // =============================================================================
 
-import type { Dispute } from '../entities/simple-entities.js';
+import type { Dispute, Donation } from '../entities/simple-entities.js';
 import type { Escrow, MilestoneCondition } from '../entities/escrow.js';
 import type { GatewayName, GatewayRef, ThreeDSChallenge } from '../value_objects/opaque-refs.js';
 import type { IdempotencyKey } from '../value_objects/idempotency-key.js';
@@ -400,6 +400,114 @@ export interface SubmitDisputeEvidenceInput {
 export interface SubmitDisputeEvidenceResult {
   readonly gatewayRef: GatewayRef;
   readonly status: Dispute['status'];
+}
+
+// ---------------------------------------------------------------------------
+// 10. DonationPort — one-time + recurring donations for altrupets-api et al.
+// ---------------------------------------------------------------------------
+
+/**
+ * Donations are distinct from generic `PaymentGatewayPort.initiate` because
+ * they carry donation-specific semantics: a `campaignId` metadata hook
+ * (opaque to payments-core, owned by the consumer backend), a recurrence
+ * specification for monthly/yearly giving, and donor-visibility flags that
+ * gate receipt-email delivery on the gateway side.
+ *
+ * Implementations are thin wrappers around the gateway's charge/subscription
+ * surfaces that tag the outbound metadata map with donation markers. See
+ * `openspec/changes/donations-port/` for the full rationale and the
+ * `crowdfunding-deferred` cross-reference.
+ */
+export interface DonationPort {
+  readonly gateway: GatewayName;
+
+  /**
+   * One-shot donation. Returns the donation id assigned by payments-core
+   * and the gateway's opaque external reference.
+   */
+  initiateOneTime(input: InitiateOneTimeDonationInput): Promise<InitiateDonationResult>;
+
+  /**
+   * Sets up a recurring donation schedule on the gateway. The first charge
+   * may happen synchronously or asynchronously depending on the gateway;
+   * the returned `gatewayRef` is the gateway's recurring-plan id, reusable
+   * as the handle passed to `pauseRecurring` / `cancelRecurring`.
+   */
+  initiateRecurring(input: InitiateRecurringDonationInput): Promise<InitiateDonationResult>;
+
+  /**
+   * Pauses an active recurring donation. Idempotent by `idempotencyKey`:
+   * pausing an already-paused schedule is a no-op and resolves successfully.
+   */
+  pauseRecurring(gatewayRef: GatewayRef, idempotencyKey: IdempotencyKey): Promise<void>;
+
+  /**
+   * Cancels a recurring donation. Idempotent by `idempotencyKey`: cancelling
+   * an already-cancelled schedule is a no-op and resolves successfully.
+   * The consumer backend still retains the historical `Donation` records.
+   */
+  cancelRecurring(gatewayRef: GatewayRef, idempotencyKey: IdempotencyKey): Promise<void>;
+}
+
+/**
+ * Interval specification for recurring donations. `custom.daysBetween` lets
+ * consumers request cadences the gateway does not model natively (the
+ * adapter maps it to the nearest supported period or raises
+ * `GatewayUnsupportedFeature` if the gateway rejects it).
+ */
+export type DonationRecurrence =
+  | { readonly interval: 'month'; readonly count: 1 }
+  | { readonly interval: 'year'; readonly count: 1 }
+  | { readonly interval: 'custom'; readonly daysBetween: number };
+
+export type DonorVisibility = 'anonymous' | 'public' | 'pseudonymous';
+
+export interface InitiateOneTimeDonationInput {
+  readonly amount: Money;
+  readonly consumer: string;
+  readonly donorReference: string;
+  /**
+   * Opaque campaign id. AltruPets attaches its own cause id here. Empty
+   * string means "no campaign"; callers that have no campaign pass `null`
+   * which the application layer coerces to empty before calling the port.
+   */
+  readonly campaignId: string | null;
+  readonly donorVisibility: DonorVisibility;
+  readonly idempotencyKey: IdempotencyKey;
+  readonly metadata: Readonly<Record<string, string>>;
+  readonly returnUrl?: string;
+  readonly cancelUrl?: string;
+}
+
+export interface InitiateRecurringDonationInput {
+  readonly amount: Money;
+  readonly consumer: string;
+  readonly donorReference: string;
+  readonly campaignId: string | null;
+  readonly donorVisibility: DonorVisibility;
+  readonly recurrence: DonationRecurrence;
+  readonly idempotencyKey: IdempotencyKey;
+  readonly metadata: Readonly<Record<string, string>>;
+  readonly returnUrl?: string;
+  readonly cancelUrl?: string;
+}
+
+export interface InitiateDonationResult {
+  readonly donationId: string;
+  readonly gatewayRef: GatewayRef;
+  readonly requiresAction: boolean;
+  readonly challenge?: ThreeDSChallenge;
+  readonly checkoutUrl?: string;
+}
+
+/**
+ * Compact reference returned by the donation use cases. The `gatewayRef`
+ * is the handle callers must present to pause/cancel a recurring donation.
+ */
+export interface DonationRef {
+  readonly donationId: string;
+  readonly gatewayRef: GatewayRef;
+  readonly kind: Donation['kind'];
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,8 @@ import {
   GatewayUnavailableError,
   createGatewayRef,
   type AgenticPaymentPort,
+  type Donation,
+  type DonationPort,
   type Escrow,
   type EscrowPort,
   type FXRatePort,
@@ -42,13 +44,16 @@ import {
 import {
   makeCancelSubscription,
   makeConfirmCheckout,
+  makeCreateOneTimeDonation,
   makeCreatePayout,
+  makeCreateRecurringDonation,
   makeCreateSubscription,
   makeDisputeEscrow,
   makeGetPaymentHistory,
   makeHandleAgenticPayment,
   makeHoldEscrow,
   makeInitiateCheckout,
+  makeManageRecurringDonation,
   makeProcessWebhook,
   makeReconcileDaily,
   makeRefundPayment,
@@ -179,6 +184,20 @@ const stubFx: FXRatePort = {
   lookup: () => unavailable(),
 };
 
+// DonationPort has no real adapter yet. Stripe and OnvoPay charges can
+// carry donation metadata through `PaymentGatewayPort`; wrapping them as
+// first-class `DonationPort` implementations lands in a follow-up change.
+// Until then, every donation RPC returns `UNAVAILABLE`.
+function stubDonationPortFor(gateway: GatewayName): DonationPort {
+  return {
+    gateway,
+    initiateOneTime: () => unavailableFor(gateway),
+    initiateRecurring: () => unavailableFor(gateway),
+    pauseRecurring: () => unavailableFor(gateway),
+    cancelRecurring: () => unavailableFor(gateway),
+  };
+}
+
 // Per-gateway stubs for the three wired ports. Only constructed when a
 // caller asks for a gateway that hasn't been registered; the stub carries
 // the requested gateway name so the error message is accurate.
@@ -268,6 +287,17 @@ class InMemoryPayoutRepo {
   }
 }
 
+class InMemoryDonationRepo {
+  private readonly items = new Map<string, Donation>();
+  save(d: Donation): Promise<void> {
+    this.items.set(d.id, d);
+    return Promise.resolve();
+  }
+  findById(id: string): Promise<Donation | null> {
+    return Promise.resolve(this.items.get(id) ?? null);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Wire + start
 // ---------------------------------------------------------------------------
@@ -284,6 +314,7 @@ function buildUseCasesInternal(env: AdapterEnv) {
   const subRepo = new InMemorySubscriptionRepo();
   const escrowRepo = new InMemoryEscrowRepo();
   const payoutRepo = new InMemoryPayoutRepo();
+  const donationRepo = new InMemoryDonationRepo();
 
   // Real adapters constructed from env; unconfigured gateways fall through
   // to per-gateway stubs that return `UNAVAILABLE` on every call.
@@ -312,6 +343,9 @@ function buildUseCasesInternal(env: AdapterEnv) {
   };
   const payoutGateways = {
     resolvePayoutGateway: (_g: GatewayName): PayoutGatewayPort => stubPayoutGateway,
+  };
+  const donationGateways = {
+    resolveDonationGateway: (g: GatewayName): DonationPort => stubDonationPortFor(g),
   };
   const verifierRegistry = {
     resolveVerifier,
@@ -390,6 +424,20 @@ function buildUseCasesInternal(env: AdapterEnv) {
     }),
     getPaymentHistory: makeGetPaymentHistory({ reader: emptyHistoryReader }),
     reconcileDaily: makeReconcileDaily({ registry: reconciliationRegistry }),
+    createOneTimeDonation: makeCreateOneTimeDonation({
+      gateways: donationGateways,
+      repo: donationRepo,
+      idempotency,
+    }),
+    createRecurringDonation: makeCreateRecurringDonation({
+      gateways: donationGateways,
+      repo: donationRepo,
+      idempotency,
+    }),
+    manageRecurringDonation: makeManageRecurringDonation({
+      gateways: donationGateways,
+      idempotency,
+    }),
   };
 }
 

--- a/test/application/donations.test.ts
+++ b/test/application/donations.test.ts
@@ -1,0 +1,503 @@
+// =============================================================================
+// Donation use-case tests — CreateOneTime / CreateRecurring / ManageRecurring.
+// -----------------------------------------------------------------------------
+// Covers every branch each use case can take:
+//   - Happy path one-time + recurring (with checkoutUrl surfaced).
+//   - Pause + cancel via ManageRecurringDonation.
+//   - Idempotency replay returns the cached result without a second port call.
+//   - Money validation: zero amount and negative amount both yield
+//     InvalidMoneyError.
+//   - campaignId: both `null` ("no campaign") and a populated string are
+//     accepted; the port receives the raw value and the Donation entity
+//     stores it (coerced to empty string when null).
+//   - Port error surfaced as err(DomainError).
+// =============================================================================
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  Money,
+  createGatewayRef,
+  idempotencyKey,
+  type Donation,
+  type DonationPort,
+  type GatewayRef,
+  type IdempotencyKey,
+  type IdempotencyPort,
+  type InitiateDonationResult,
+} from '../../src/domain/index.js';
+import {
+  makeCreateOneTimeDonation,
+  makeCreateRecurringDonation,
+  makeManageRecurringDonation,
+  type DonationRegistryPort,
+  type DonationRepositoryPort,
+} from '../../src/application/use_cases/donations.js';
+
+// ---------------------------------------------------------------------------
+// Shared test helpers
+// ---------------------------------------------------------------------------
+
+const key = (suffix: string): IdempotencyKey => idempotencyKey(`test-don-${suffix}`);
+const usd = (n: bigint): Money => Money.of(n, 'USD');
+const gatewayRefOf = (id: string): GatewayRef => {
+  const r = createGatewayRef('stripe', id);
+  if (!r.ok) throw r.error;
+  return r.value;
+};
+
+const makeIdem = (): IdempotencyPort => {
+  const store = new Map<string, unknown>();
+  return {
+    check: async <T>(k: IdempotencyKey) => (store.has(k) ? (store.get(k) as T) : null),
+    commit: async <T>(k: IdempotencyKey, r: T) => {
+      store.set(k, r);
+    },
+  };
+};
+
+const makeRepo = (): DonationRepositoryPort & {
+  readonly store: Map<string, Donation>;
+} => {
+  const store = new Map<string, Donation>();
+  return {
+    store,
+    save: async (d) => {
+      store.set(d.id, d);
+    },
+    findById: async (id) => store.get(id) ?? null,
+  };
+};
+
+const stubPort = (overrides: Partial<DonationPort> = {}): DonationPort => ({
+  gateway: 'stripe',
+  initiateOneTime: vi.fn(
+    async (): Promise<InitiateDonationResult> => ({
+      donationId: 'don_1',
+      gatewayRef: gatewayRefOf('ch_ot_1'),
+      requiresAction: false,
+      checkoutUrl: 'https://checkout.stripe.com/pay/ot_1',
+    }),
+  ),
+  initiateRecurring: vi.fn(
+    async (): Promise<InitiateDonationResult> => ({
+      donationId: 'don_2',
+      gatewayRef: gatewayRefOf('sub_rec_1'),
+      requiresAction: false,
+    }),
+  ),
+  pauseRecurring: vi.fn(async () => undefined),
+  cancelRecurring: vi.fn(async () => undefined),
+  ...overrides,
+});
+
+const stubRegistry = (port: DonationPort): DonationRegistryPort => ({
+  resolveDonationGateway: () => port,
+});
+
+// ---------------------------------------------------------------------------
+// CreateOneTimeDonation
+// ---------------------------------------------------------------------------
+
+describe('makeCreateOneTimeDonation', () => {
+  let idem: IdempotencyPort;
+  let repo: ReturnType<typeof makeRepo>;
+
+  beforeEach(() => {
+    idem = makeIdem();
+    repo = makeRepo();
+  });
+
+  it('persists a one-time donation and surfaces checkoutUrl', async () => {
+    const port = stubPort();
+    const execute = makeCreateOneTimeDonation({
+      gateways: stubRegistry(port),
+      repo,
+      idempotency: idem,
+    });
+
+    const r = await execute({
+      id: 'don_a',
+      consumer: 'altrupets-api',
+      donorReference: 'donor-42',
+      amount: usd(5000n),
+      gateway: 'stripe',
+      campaignId: 'altrupets-2026-adoption',
+      donorVisibility: 'public',
+      idempotencyKey: key('ot-happy'),
+    });
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.ref.donationId).toBe('don_a');
+    expect(r.value.ref.kind).toBe('one_time');
+    expect(r.value.checkoutUrl).toBe('https://checkout.stripe.com/pay/ot_1');
+    expect(r.value.donation.status).toBe('pending');
+    expect(r.value.donation.campaignId).toBe('altrupets-2026-adoption');
+    expect(r.value.donation.metadata['donation']).toBe('true');
+    expect(r.value.donation.metadata['campaign_id']).toBe('altrupets-2026-adoption');
+    expect(r.value.donation.metadata['donor_visibility']).toBe('public');
+    expect(repo.store.get('don_a')?.gatewayRef?.externalId).toBe('ch_ot_1');
+    expect(port.initiateOneTime).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a null campaignId and coerces to empty string on the entity', async () => {
+    const port = stubPort();
+    const execute = makeCreateOneTimeDonation({
+      gateways: stubRegistry(port),
+      repo,
+      idempotency: idem,
+    });
+
+    const r = await execute({
+      id: 'don_nocamp',
+      consumer: 'altrupets-api',
+      donorReference: 'donor-99',
+      amount: usd(1200n),
+      gateway: 'stripe',
+      campaignId: null,
+      donorVisibility: 'anonymous',
+      idempotencyKey: key('ot-nocamp'),
+    });
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.donation.campaignId).toBe('');
+    // `campaign_id` metadata is omitted entirely when no campaign is attached.
+    expect(r.value.donation.metadata['campaign_id']).toBeUndefined();
+    expect(r.value.donation.metadata['donor_visibility']).toBe('anonymous');
+  });
+
+  it('replays idempotently without re-calling the port', async () => {
+    const port = stubPort();
+    const execute = makeCreateOneTimeDonation({
+      gateways: stubRegistry(port),
+      repo,
+      idempotency: idem,
+    });
+    const input = {
+      id: 'don_idem',
+      consumer: 'altrupets-api',
+      donorReference: 'donor-1',
+      amount: usd(2500n),
+      gateway: 'stripe' as const,
+      campaignId: null,
+      donorVisibility: 'pseudonymous' as const,
+      idempotencyKey: key('ot-idem'),
+    };
+    const first = await execute(input);
+    const second = await execute(input);
+    expect(first.ok && second.ok).toBe(true);
+    expect(port.initiateOneTime).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects zero-amount donations with InvalidMoneyError', async () => {
+    const port = stubPort();
+    const execute = makeCreateOneTimeDonation({
+      gateways: stubRegistry(port),
+      repo,
+      idempotency: idem,
+    });
+    const r = await execute({
+      id: 'don_zero',
+      consumer: 'altrupets-api',
+      donorReference: 'donor-0',
+      amount: usd(0n),
+      gateway: 'stripe',
+      campaignId: null,
+      donorVisibility: 'public',
+      idempotencyKey: key('ot-zero'),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('DOMAIN_INVALID_MONEY');
+    expect(port.initiateOneTime).not.toHaveBeenCalled();
+  });
+
+  it('rejects negative-amount donations (defence in depth)', async () => {
+    // `Money.of` already rejects negatives, so we fake a Money-shaped object
+    // to exercise the second-line-of-defence branch inside the validator.
+    const negative = Object.create(Money.prototype) as Money;
+    Object.assign(negative, { amountMinor: -100n, currency: 'USD' });
+    const port = stubPort();
+    const execute = makeCreateOneTimeDonation({
+      gateways: stubRegistry(port),
+      repo,
+      idempotency: idem,
+    });
+    const r = await execute({
+      id: 'don_neg',
+      consumer: 'altrupets-api',
+      donorReference: 'donor-n',
+      amount: negative,
+      gateway: 'stripe',
+      campaignId: null,
+      donorVisibility: 'public',
+      idempotencyKey: key('ot-neg'),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('DOMAIN_INVALID_MONEY');
+    expect(port.initiateOneTime).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a gateway error as err(DomainError)', async () => {
+    const port = stubPort({
+      initiateOneTime: vi.fn(async () => {
+        throw new Error('network blip');
+      }),
+    });
+    const execute = makeCreateOneTimeDonation({
+      gateways: stubRegistry(port),
+      repo,
+      idempotency: idem,
+    });
+    const r = await execute({
+      id: 'don_fail',
+      consumer: 'altrupets-api',
+      donorReference: 'donor-x',
+      amount: usd(100n),
+      gateway: 'stripe',
+      campaignId: 'c-1',
+      donorVisibility: 'public',
+      idempotencyKey: key('ot-fail'),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('APPLICATION_UNEXPECTED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CreateRecurringDonation
+// ---------------------------------------------------------------------------
+
+describe('makeCreateRecurringDonation', () => {
+  let idem: IdempotencyPort;
+  let repo: ReturnType<typeof makeRepo>;
+
+  beforeEach(() => {
+    idem = makeIdem();
+    repo = makeRepo();
+  });
+
+  it('persists a recurring donation and records the recurrence interval metadata', async () => {
+    const port = stubPort();
+    const execute = makeCreateRecurringDonation({
+      gateways: stubRegistry(port),
+      repo,
+      idempotency: idem,
+    });
+
+    const r = await execute({
+      id: 'don_rec_m',
+      consumer: 'altrupets-api',
+      donorReference: 'donor-rec',
+      amount: usd(2500n),
+      gateway: 'stripe',
+      campaignId: 'altrupets-2026-adoption',
+      donorVisibility: 'pseudonymous',
+      recurrence: { interval: 'month', count: 1 },
+      idempotencyKey: key('rec-happy'),
+    });
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.ref.kind).toBe('recurring');
+    expect(r.value.donation.kind).toBe('recurring');
+    expect(r.value.donation.status).toBe('pending');
+    expect(r.value.donation.metadata['recurrence_interval']).toBe('month');
+    expect(r.value.donation.metadata['recurrence_count']).toBe('1');
+    expect(port.initiateRecurring).toHaveBeenCalledTimes(1);
+  });
+
+  it('encodes custom recurrence via daysBetween', async () => {
+    const port = stubPort();
+    const execute = makeCreateRecurringDonation({
+      gateways: stubRegistry(port),
+      repo,
+      idempotency: idem,
+    });
+
+    const r = await execute({
+      id: 'don_rec_c',
+      consumer: 'altrupets-api',
+      donorReference: 'donor-c',
+      amount: usd(1000n),
+      gateway: 'stripe',
+      campaignId: null,
+      donorVisibility: 'public',
+      recurrence: { interval: 'custom', daysBetween: 14 },
+      idempotencyKey: key('rec-custom'),
+    });
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.donation.metadata['recurrence_interval']).toBe('custom');
+    expect(r.value.donation.metadata['recurrence_days_between']).toBe('14');
+    expect(r.value.donation.metadata['recurrence_count']).toBeUndefined();
+  });
+
+  it('replays idempotently without re-calling the port', async () => {
+    const port = stubPort();
+    const execute = makeCreateRecurringDonation({
+      gateways: stubRegistry(port),
+      repo,
+      idempotency: idem,
+    });
+    const input = {
+      id: 'don_rec_idem',
+      consumer: 'altrupets-api',
+      donorReference: 'donor-i',
+      amount: usd(500n),
+      gateway: 'stripe' as const,
+      campaignId: null,
+      donorVisibility: 'public' as const,
+      recurrence: { interval: 'year' as const, count: 1 as const },
+      idempotencyKey: key('rec-idem'),
+    };
+    await execute(input);
+    await execute(input);
+    expect(port.initiateRecurring).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects zero-amount recurring donations', async () => {
+    const port = stubPort();
+    const execute = makeCreateRecurringDonation({
+      gateways: stubRegistry(port),
+      repo,
+      idempotency: idem,
+    });
+    const r = await execute({
+      id: 'don_rec_zero',
+      consumer: 'altrupets-api',
+      donorReference: 'donor-0',
+      amount: usd(0n),
+      gateway: 'stripe',
+      campaignId: null,
+      donorVisibility: 'public',
+      recurrence: { interval: 'month', count: 1 },
+      idempotencyKey: key('rec-zero'),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('DOMAIN_INVALID_MONEY');
+    expect(port.initiateRecurring).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a gateway error as err(DomainError)', async () => {
+    const port = stubPort({
+      initiateRecurring: vi.fn(async () => {
+        throw new Error('gateway refused');
+      }),
+    });
+    const execute = makeCreateRecurringDonation({
+      gateways: stubRegistry(port),
+      repo,
+      idempotency: idem,
+    });
+    const r = await execute({
+      id: 'don_rec_err',
+      consumer: 'altrupets-api',
+      donorReference: 'donor-e',
+      amount: usd(100n),
+      gateway: 'stripe',
+      campaignId: null,
+      donorVisibility: 'public',
+      recurrence: { interval: 'month', count: 1 },
+      idempotencyKey: key('rec-err'),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('APPLICATION_UNEXPECTED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ManageRecurringDonation
+// ---------------------------------------------------------------------------
+
+describe('makeManageRecurringDonation', () => {
+  let idem: IdempotencyPort;
+
+  beforeEach(() => {
+    idem = makeIdem();
+  });
+
+  it('pauses a recurring donation by gatewayRef', async () => {
+    const port = stubPort();
+    const execute = makeManageRecurringDonation({
+      gateways: stubRegistry(port),
+      idempotency: idem,
+    });
+
+    const r = await execute({
+      action: 'pause',
+      gatewayRef: gatewayRefOf('sub_rec_p'),
+      idempotencyKey: key('pause'),
+    });
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.action).toBe('pause');
+    expect(port.pauseRecurring).toHaveBeenCalledTimes(1);
+    expect(port.cancelRecurring).not.toHaveBeenCalled();
+  });
+
+  it('cancels a recurring donation by gatewayRef', async () => {
+    const port = stubPort();
+    const execute = makeManageRecurringDonation({
+      gateways: stubRegistry(port),
+      idempotency: idem,
+    });
+
+    const r = await execute({
+      action: 'cancel',
+      gatewayRef: gatewayRefOf('sub_rec_c'),
+      idempotencyKey: key('cancel'),
+    });
+
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.value.action).toBe('cancel');
+    expect(port.cancelRecurring).toHaveBeenCalledTimes(1);
+    expect(port.pauseRecurring).not.toHaveBeenCalled();
+  });
+
+  it('replays pause/cancel idempotently', async () => {
+    const port = stubPort();
+    const execute = makeManageRecurringDonation({
+      gateways: stubRegistry(port),
+      idempotency: idem,
+    });
+
+    const input = {
+      action: 'cancel' as const,
+      gatewayRef: gatewayRefOf('sub_rec_idem'),
+      idempotencyKey: key('manage-idem'),
+    };
+    await execute(input);
+    await execute(input);
+    expect(port.cancelRecurring).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a gateway error from pause as err(DomainError)', async () => {
+    const port = stubPort({
+      pauseRecurring: vi.fn(async () => {
+        throw new Error('subscription missing');
+      }),
+    });
+    const execute = makeManageRecurringDonation({
+      gateways: stubRegistry(port),
+      idempotency: idem,
+    });
+    const r = await execute({
+      action: 'pause',
+      gatewayRef: gatewayRefOf('sub_missing'),
+      idempotencyKey: key('pause-err'),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.code).toBe('APPLICATION_UNEXPECTED');
+  });
+});


### PR DESCRIPTION
Closes #27

## Summary

Adds the domain-level `DonationPort` interface and three application-layer wrapper use cases that honor the AltruPets-driven `campaign_id` metadata hook declared in `openspec/changes/donations-port/`.

## Port signature (new in `src/domain/ports/index.ts`)

```ts
export interface DonationPort {
  readonly gateway: GatewayName;
  initiateOneTime(input: InitiateOneTimeDonationInput): Promise<InitiateDonationResult>;
  initiateRecurring(input: InitiateRecurringDonationInput): Promise<InitiateDonationResult>;
  pauseRecurring(gatewayRef: GatewayRef, idempotencyKey: IdempotencyKey): Promise<void>;
  cancelRecurring(gatewayRef: GatewayRef, idempotencyKey: IdempotencyKey): Promise<void>;
}
```

Supporting types co-located on the same file (`DonorVisibility`, `DonationRecurrence`, `DonationRef`, `InitiateOneTimeDonationInput`, `InitiateRecurringDonationInput`, `InitiateDonationResult`).

- Uses `GatewayName` (concrete providers only). `GatewayPreference` stays at the transport layer.
- Domain-layer only — no SDK, no I/O, passes the `no-restricted-imports` guard.

## Use cases (`src/application/use_cases/donations.ts`)

1. **CreateOneTimeDonation** — validates `Money > 0`, idempotency-checks, enriches metadata with `donation=true`, `donor_visibility`, and `campaign_id` (when provided), calls `DonationPort.initiateOneTime`, persists a `Donation` entity with kind `one_time`, returns a `DonationRef`.
2. **CreateRecurringDonation** — same shape plus a `recurrence` spec (`month`/`year`/`custom`); adds `recurrence_interval` / `recurrence_count` / `recurrence_days_between` to metadata; persists kind `recurring`.
3. **ManageRecurringDonation** — discriminated union input (`action: 'pause' | 'cancel'`) addressed by `gatewayRef`. Idempotent by key — replays no-op.

All three use cases:
- Return `Result<T, DomainError>`; never throw.
- Enforce `IdempotencyPort.check` before any side effect.
- Use the existing `Donation` entity (no new state machine) — pause/cancel operate on the gateway-side recurring schedule addressed by `gatewayRef`, which is why they do not transition a stored `Donation` row.

## `campaign_id` hook

- Passed through to the port as `string | null`.
- Stored on `Donation.campaignId` (coerced to `''` when null).
- Emitted on the metadata map as `campaign_id=<value>` only when present. Never interpreted by payments-core.

## Adapter wrappers — deferred

`StripeDonationAdapter` and `OnvoPayDonationAdapter` are deferred to a follow-up change to keep this PR at 6 files, well under the 15-file budget. The composition root (`src/main.ts`) wires a `stubDonationPortFor(gateway)` that raises `GatewayUnavailableError`, so donation RPCs return `UNAVAILABLE` until adapters land. The use cases already enrich the metadata on the domain side, so the adapter change only needs to pass it through.

## Tests (15 new, all passing; 189 total)

- Happy path one-time + recurring (checkoutUrl surfaced, metadata recorded).
- Idempotency replay: second call returns the cached result; port is invoked exactly once.
- Money validation: zero amount + negative amount both yield `InvalidMoneyError`.
- `campaignId` null vs provided: both accepted; entity stores empty string for null; metadata key omitted when no campaign.
- `custom` recurrence with `daysBetween` path.
- Pause + cancel via `ManageRecurringDonation`, including idempotent replay and gateway error surfacing.

```
 Test Files  15 passed (15)
      Tests  189 passed (189)
```

Coverage for `donations.ts`: 6/6 functions hit.

## OpenSpec reconciliation

`openspec/changes/donations-port/tasks.md` updated: port + use case + test items checked off; adapter/repository/events/docs items annotated as deferred with rationale. Added a header noting this PR delivers the port and use-case slice; the Postgres repository, event emission, and documentation page land in follow-ups.

## Files changed (6)

- `src/domain/ports/index.ts` — adds `DonationPort` + input/result types.
- `src/application/use_cases/donations.ts` — new file, 3 use cases.
- `src/application/index.ts` — barrel exports.
- `src/main.ts` — stub `DonationPort` + `InMemoryDonationRepo` wired into `buildUseCasesInternal`.
- `test/application/donations.test.ts` — 15 new unit tests.
- `openspec/changes/donations-port/tasks.md` — reconciliation.

## Test plan

- [x] `pnpm lint` green
- [x] `pnpm build` green
- [x] `pnpm test` — 189/189 tests pass
- [x] `pnpm test -- --coverage` — post-PR #41 coverage still works, donations.ts 6/6 funcs covered
- [x] 15-file rule honored (6 files)
- [x] No direct adapter imports in domain or application layer
- [x] `Result<T, DomainError>` throughout — never throws
- [x] No debug logs or top-level side effects

Created by Claude Code on behalf of @lapc506